### PR TITLE
Only use district number 22 for harvester’s default parameter

### DIFF
--- a/src/schemas/kulturdaten.berlin.openapi.base.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.base.yml
@@ -1478,7 +1478,7 @@ paths:
           application/json:    
             schema:
               type: array
-              default: ['2','4','5','6','7','8','9','10','11','12','13','22','25']
+              default: ['22']
               items:
                 type: string
       responses:

--- a/src/schemas/kulturdaten.berlin.openapi.generated.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.generated.yml
@@ -1427,19 +1427,7 @@ paths:
             schema:
               type: array
               default:
-                - '2'
-                - '4'
-                - '5'
-                - '6'
-                - '7'
-                - '8'
-                - '9'
-                - '10'
-                - '11'
-                - '12'
-                - '13'
                 - '22'
-                - '25'
               items:
                 type: string
       responses:


### PR DESCRIPTION
District 22 contains some of the "Exkursion" events we need for our example prompts, so we should include it in our default harvesting behavior. #wasserbüffel