### PR TITLE
fix: load local environment variables correctly

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,5 @@
 import cors from "cors";
-import * as dotenv from "dotenv";
+import "dotenv/config";
 import express from "express";
 import * as OpenApiValidator from "express-openapi-validator";
 import * as expressWinston from "express-winston";
@@ -34,8 +34,6 @@ import { TagsRoutes } from "./resources/tags/tags.routes";
 import { UsersRoutes } from "./resources/users/UsersRoutes";
 import { MongoDBUsersRepository } from "./resources/users/repositories/MongoDBUsersRepository";
 import { UsersService } from "./resources/users/services/UsersService";
-
-dotenv.config();
 
 export class KulturdatenBerlinApp {
 	constructor(public app: express.Application) {}


### PR DESCRIPTION
#43 broke the local environment variable loading (and thus MongoDB connection), because `dotenv.config();` was moved below the imports in `app.ts` that depended on it. This fixes the issue by importing `dotenv/config`, which directly loads the environment variables without an extra command (and it’s thus early enough for the other imports to have the variables available).