### PR TITLE
feat: return events sorted by their start date and time

### DIFF
--- a/src/utils/DateTimeUtil.ts
+++ b/src/utils/DateTimeUtil.ts
@@ -1,3 +1,9 @@
+import { Event } from "../generated/models/Event.generated";
+
 export const getTodayAsString = () => {
 	return new Date().toISOString().slice(0, 10);
+};
+
+export const getStartDateAsISO = (event: Event) => {
+	return `${event.schedule?.startDate}T${event.schedule?.startTime || ""}`;
 };


### PR DESCRIPTION
Adds sorting to our events query. For now, we always sort by date and time (from old to new). We can make this more flexible in the future, but for now this is a sensible default.

Also uses slightly stricter types for `MongoDBEventsRepository.get()`.