### PR TITLE
refactor: use proper typings for AuthUser

### DIFF
--- a/src/resources/auth/controllers/AuthController.ts
+++ b/src/resources/auth/controllers/AuthController.ts
@@ -4,8 +4,8 @@ import jwt from "jsonwebtoken";
 import { Service } from "typedi";
 import { ErrorResponseBuilder, SuccessResponseBuilder } from "../../../common/responses/SuccessResponseBuilder";
 import { LoginResponse } from "../../../generated/models/LoginResponse.generated";
-import { User } from "../../../generated/models/User.generated";
 import { UsersService } from "../../users/services/UsersService";
+import { AuthUser } from "../strategies/AuthPasswordStrategy";
 
 const log: debug.IDebugger = debug("app:auth-controller");
 
@@ -19,15 +19,14 @@ export class AuthController {
 
 	async login(req: express.Request, res: express.Response) {
 		if (req.user) {
-			const requestUser = req.user as User;
-			const email = requestUser.email;
-			const user = await this.usersService.getUserByEmail(email);
+			const authUser = req.user as AuthUser;
+			const token = jwt.sign(authUser, jwtSecret, {
+				expiresIn: authTokenExpiresIn,
+			});
+			const user = await this.usersService.readById(authUser.identifier);
 			if (!user) {
 				return res.status(404).send(new ErrorResponseBuilder().notFoundResponse("User not found").build());
 			}
-			const token = jwt.sign(req.user, jwtSecret, {
-				expiresIn: authTokenExpiresIn,
-			});
 			return res.status(200).send(
 				new SuccessResponseBuilder<LoginResponse>()
 					.okResponse({


### PR DESCRIPTION
This cleans up the user-related TypeScript types in `AuthPasswordStrategy.ts`, properly reads the `identifier` field and looks up the user via its identifier (rather than email address).