### PR TITLE
feat: create metadata timestamps and identifiers upon creation/updates

### DIFF
--- a/src/admin/districtData/services/DistrictDataMapper.unit.test.ts
+++ b/src/admin/districtData/services/DistrictDataMapper.unit.test.ts
@@ -4,6 +4,7 @@ import {
 } from "../../../generated/models/CreateAttractionRequest.generated";
 import { CreateEventRequest, validateCreateEventRequest } from "../../../generated/models/CreateEventRequest.generated";
 import { Tag } from "../../../generated/models/Tag.generated";
+import { getCurrentTimestamp } from "../../../utils/MetadataUtil";
 import { Termin, Veranstaltung } from "../model/Bezirksdaten";
 import { DistrictDataMapper } from "./DistrictDataMapper";
 
@@ -121,6 +122,8 @@ describe("DistrictDataMapper", () => {
 	});
 });
 
+const currentTimestamp = getCurrentTimestamp();
+
 const tags: Tag[] = [
 	{
 		type: "type.Tag",
@@ -129,6 +132,8 @@ const tags: Tag[] = [
 			de: "Infoveranstaltungen",
 		},
 		metadata: {
+			created: currentTimestamp,
+			updated: currentTimestamp,
 			externalIDs: {
 				bezirkskalender: "121",
 			},
@@ -141,6 +146,8 @@ const tags: Tag[] = [
 			de: "Konferenzen, Messen",
 		},
 		metadata: {
+			created: currentTimestamp,
+			updated: currentTimestamp,
 			externalIDs: {
 				bezirkskalender: "120",
 			},
@@ -153,6 +160,8 @@ const tags: Tag[] = [
 			de: "Bildung, Schule",
 		},
 		metadata: {
+			created: currentTimestamp,
+			updated: currentTimestamp,
 			externalIDs: {
 				bezirkskalender: "118",
 			},
@@ -165,6 +174,8 @@ const tags: Tag[] = [
 			de: "Kunst, Kultur",
 		},
 		metadata: {
+			created: currentTimestamp,
+			updated: currentTimestamp,
 			externalIDs: {
 				bezirkskalender: "180",
 			},
@@ -177,6 +188,8 @@ const tags: Tag[] = [
 			de: "Polizei",
 		},
 		metadata: {
+			created: currentTimestamp,
+			updated: currentTimestamp,
 			externalIDs: {
 				bezirkskalender: "94",
 			},
@@ -189,6 +202,8 @@ const tags: Tag[] = [
 			de: "Ausstellungen",
 		},
 		metadata: {
+			created: currentTimestamp,
+			updated: currentTimestamp,
 			externalIDs: {
 				bezirkskalender: "1",
 			},
@@ -201,6 +216,8 @@ const tags: Tag[] = [
 			de: "Bühnen, Filme",
 		},
 		metadata: {
+			created: currentTimestamp,
+			updated: currentTimestamp,
 			externalIDs: {
 				bezirkskalender: "10",
 			},
@@ -213,6 +230,8 @@ const tags: Tag[] = [
 			de: "Feste, Events",
 		},
 		metadata: {
+			created: currentTimestamp,
+			updated: currentTimestamp,
 			externalIDs: {
 				bezirkskalender: "2",
 			},
@@ -225,6 +244,8 @@ const tags: Tag[] = [
 			de: "Frauen",
 		},
 		metadata: {
+			created: currentTimestamp,
+			updated: currentTimestamp,
 			externalIDs: {
 				bezirkskalender: "17",
 			},
@@ -237,6 +258,8 @@ const tags: Tag[] = [
 			de: "Gesundheit, Umwelt",
 		},
 		metadata: {
+			created: currentTimestamp,
+			updated: currentTimestamp,
 			externalIDs: {
 				bezirkskalender: "19",
 			},
@@ -249,6 +272,8 @@ const tags: Tag[] = [
 			de: "Kinder, Jugendliche",
 		},
 		metadata: {
+			created: currentTimestamp,
+			updated: currentTimestamp,
 			externalIDs: {
 				bezirkskalender: "3",
 			},
@@ -261,6 +286,8 @@ const tags: Tag[] = [
 			de: "Lesungen, Vorträge",
 		},
 		metadata: {
+			created: currentTimestamp,
+			updated: currentTimestamp,
 			externalIDs: {
 				bezirkskalender: "4",
 			},
@@ -273,6 +300,8 @@ const tags: Tag[] = [
 			de: "Musik, Konzerte",
 		},
 		metadata: {
+			created: currentTimestamp,
+			updated: currentTimestamp,
 			externalIDs: {
 				bezirkskalender: "5",
 			},
@@ -285,6 +314,8 @@ const tags: Tag[] = [
 			de: "Politik, Bürgerservice",
 		},
 		metadata: {
+			created: currentTimestamp,
+			updated: currentTimestamp,
 			externalIDs: {
 				bezirkskalender: "7",
 			},
@@ -297,6 +328,8 @@ const tags: Tag[] = [
 			de: "Spaziergänge, Ausflüge",
 		},
 		metadata: {
+			created: currentTimestamp,
+			updated: currentTimestamp,
 			externalIDs: {
 				bezirkskalender: "21",
 			},
@@ -309,6 +342,8 @@ const tags: Tag[] = [
 			de: "Senioren",
 		},
 		metadata: {
+			created: currentTimestamp,
+			updated: currentTimestamp,
 			externalIDs: {
 				bezirkskalender: "223",
 			},
@@ -321,6 +356,8 @@ const tags: Tag[] = [
 			de: "Freizeit, Sport",
 		},
 		metadata: {
+			created: currentTimestamp,
+			updated: currentTimestamp,
 			externalIDs: {
 				bezirkskalender: "9",
 			},
@@ -333,6 +370,8 @@ const tags: Tag[] = [
 			de: "Tanz, Theater",
 		},
 		metadata: {
+			created: currentTimestamp,
+			updated: currentTimestamp,
 			externalIDs: {
 				bezirkskalender: "42",
 			},
@@ -345,6 +384,8 @@ const tags: Tag[] = [
 			de: "Wochen- und Flohmärkte",
 		},
 		metadata: {
+			created: currentTimestamp,
+			updated: currentTimestamp,
 			externalIDs: {
 				bezirkskalender: "34",
 			},
@@ -357,6 +398,8 @@ const tags: Tag[] = [
 			de: "Weihnachtszeit, Jahreswechsel",
 		},
 		metadata: {
+			created: currentTimestamp,
+			updated: currentTimestamp,
 			externalIDs: {
 				bezirkskalender: "32",
 			},

--- a/src/integrationtests/LocationsResources.integration.test.ts
+++ b/src/integrationtests/LocationsResources.integration.test.ts
@@ -1,7 +1,7 @@
 import request from "supertest";
 
 import { fakeCreateLocationRequest } from "../generated/faker/faker.CreateLocationRequest.generated";
-import { validateLocation } from "../generated/models/Location.generated";
+import { Location, validateLocation } from "../generated/models/Location.generated";
 import { TestEnvironment } from "./integrationtestutils/TestEnvironment";
 import { LOCATION_IDENTIFIER_REG_EX } from "./integrationtestutils/testmatcher";
 
@@ -12,10 +12,12 @@ let env!: TestEnvironment;
 beforeAll(async () => {
 	env = new TestEnvironment();
 	(await env.startServer()).withLocationsRoutes();
+	jest.useFakeTimers({ advanceTimers: true });
 });
 
 afterAll(async () => {
 	await env.stopServer();
+	jest.useRealTimers();
 });
 
 describe("Validate testData", () => {
@@ -50,9 +52,21 @@ describe("Create locations", () => {
 
 		const newLocationID = body.data.locationReference.referenceId;
 		expect(newLocationID).toMatch(LOCATION_IDENTIFIER_REG_EX);
-		const loc = await env.locations.findOne({ identifier: newLocationID });
+		const createdLocation = await env.locations.findOne<Location>({ identifier: newLocationID });
+		expect(createdLocation!.title!.de).toBe("New Location");
+	});
 
-		expect(loc?.title.de).toBe("New Location");
+	it("should create default metadata with a started and updated timestamp / POST /locations", async () => {
+		jest.setSystemTime(new Date("2023-10-01T01:02:03.000Z"));
+		const { body } = await request(env.app)
+			.post(env.LOCATIONS_ROUTE)
+			.set("Authorization", `Bearer ` + env.USER_TOKEN)
+			.send(fakeCreateLocationRequest(false, { title: { de: "New Location" } }));
+		const newLocationID = body.data.locationReference.referenceId;
+		const createdLocation = await env.locations.findOne<Location>({ identifier: newLocationID });
+		const metadata = createdLocation!.metadata!;
+		expect(metadata.created).toBe("2023-10-01T01:02:03.000Z");
+		expect(metadata.updated).toBe("2023-10-01T01:02:03.000Z");
 	});
 });
 
@@ -119,8 +133,24 @@ describe("Update locations", () => {
 			});
 
 		expect(statusCode).toBe(200);
-		const loc = await env.locations.findOne({ identifier: "LOC-12345678" });
-		expect(loc?.title.de).toBe("Neuer Name");
+		const updatedLocation = await env.locations.findOne<Location>({ identifier: "LOC-12345678" });
+		expect(updatedLocation!.title!.de).toBe("Neuer Name");
+	});
+
+	it("should keep the created timestamp and update the updated timestamp of a event / PATCH /locations/existID", async () => {
+		const identifier = "LOC-12345678";
+		const existingLocation = await env.locations.findOne<Location>({ identifier });
+		jest.setSystemTime(new Date("2023-10-23T01:02:03.000Z"));
+		await request(env.app)
+			.patch(env.LOCATIONS_ROUTE + "/" + identifier)
+			.set("Authorization", `Bearer ` + env.USER_TOKEN)
+			.send({
+				title: { de: "Neuer Name" },
+			});
+		const updatedLocation = await env.locations.findOne<Location>({ identifier });
+		const metadata = updatedLocation!.metadata!;
+		expect(metadata.created).toBe(existingLocation!.metadata!.created);
+		expect(metadata.updated).toBe("2023-10-23T01:02:03.000Z");
 	});
 
 	it("should return an error when an invalid ID is provided / PATCH /locations/invalidID", async () => {

--- a/src/resources/events/controllers/EventsController.ts
+++ b/src/resources/events/controllers/EventsController.ts
@@ -6,7 +6,6 @@ import { ErrorResponseBuilder, SuccessResponseBuilder } from "../../../common/re
 import { AddEventAttractionRequest } from "../../../generated/models/AddEventAttractionRequest.generated";
 import { AddEventLocationRequest } from "../../../generated/models/AddEventLocationRequest.generated";
 import { CreateEventRequest } from "../../../generated/models/CreateEventRequest.generated";
-import { Reference } from "../../../generated/models/Reference.generated";
 import { RemoveEventAttractionRequest } from "../../../generated/models/RemoveEventAttractionRequest.generated";
 import { RemoveEventLocationRequest } from "../../../generated/models/RemoveEventLocationRequest.generated";
 import { RescheduleEventRequest } from "../../../generated/models/RescheduleEventRequest.generated";
@@ -87,14 +86,10 @@ export class EventsController {
 		}
 	}
 
-	async createEvents(res: express.Response, createEventRequest: CreateEventRequest[]) {
-		const eventsReferences: Promise<Reference | null>[] = [];
-		createEventRequest.forEach(async (request) => {
-			eventsReferences.push(this.eventsService.create(request));
-		});
-		const eR = await Promise.all(eventsReferences);
-
-		res.status(201).send(new SuccessResponseBuilder().okResponse({ events: eR }).build());
+	async createEvents(res: express.Response, createEventRequests: CreateEventRequest[]) {
+		const promises = createEventRequests.map(async (request) => this.eventsService.create(request));
+		const eventReferences = await Promise.all(promises);
+		res.status(201).send(new SuccessResponseBuilder().okResponse({ events: eventReferences }).build());
 	}
 
 	public async duplicateEvent(res: express.Response, identifier: string): Promise<void> {

--- a/src/resources/tags/repositories/MongoDBTagsRepository.ts
+++ b/src/resources/tags/repositories/MongoDBTagsRepository.ts
@@ -3,15 +3,19 @@ import { MongoDBConnector } from "../../../common/services/MongoDBConnector";
 import { CreateTagRequest } from "../../../generated/models/CreateTagRequest.generated";
 import { Filter } from "../../../generated/models/Filter.generated";
 import { Tag } from "../../../generated/models/Tag.generated";
+import { generateTagID } from "../../../utils/IDUtil";
+import { createMetadata } from "../../../utils/MetadataUtil";
 import { TagsRepository } from "./TagsRepository";
 
 @Service()
 export class MongoDBTagsRepository implements TagsRepository {
 	constructor(@Inject("DBClient") private dbConnector: MongoDBConnector) {}
+
 	async searchTags(filter: Filter): Promise<Tag[]> {
 		const tags = await this.dbConnector.tags();
 		return tags.find(filter, { projection: { _id: 0 } }).toArray();
 	}
+
 	async getTags(): Promise<Tag[]> {
 		const tags = await this.dbConnector.tags();
 		return tags.find({}, { projection: { _id: 0 } }).toArray();
@@ -21,6 +25,7 @@ export class MongoDBTagsRepository implements TagsRepository {
 		const tags = await this.dbConnector.tags();
 		return tags.find({}, { projection: { _id: 0 } }).toArray();
 	}
+
 	async getTagByIdentifier(tagId: string): Promise<Tag | null> {
 		const tags = await this.dbConnector.tags();
 		return tags.findOne({ identifier: tagId }, { projection: { _id: 0 } });
@@ -28,11 +33,18 @@ export class MongoDBTagsRepository implements TagsRepository {
 
 	async addTag(createTagRequest: CreateTagRequest): Promise<Tag | null> {
 		const tags = await this.dbConnector.tags();
-		const result = await tags.insertOne(createTagRequest);
-
+		const newTag: Tag = {
+			...createTagRequest,
+			identifier: generateTagID(),
+			metadata: {
+				...createTagRequest.metadata,
+				...createMetadata(),
+			},
+		};
+		const result = await tags.insertOne(newTag);
 		if (!result.acknowledged) {
 			return null;
 		}
-		return createTagRequest as Tag;
+		return newTag;
 	}
 }

--- a/src/resources/users/repositories/MongoDBUsersRepository.ts
+++ b/src/resources/users/repositories/MongoDBUsersRepository.ts
@@ -6,6 +6,7 @@ import { CreateUserRequest } from "../../../generated/models/CreateUserRequest.g
 import { UpdateUserRequest } from "../../../generated/models/UpdateUserRequest.generated";
 import { User } from "../../../generated/models/User.generated";
 import { generateID } from "../../../utils/IDUtil";
+import { createMetadata, getUpdatedMetadata } from "../../../utils/MetadataUtil";
 import { UsersRepository } from "./UsersRepository";
 
 @Service()
@@ -13,47 +14,55 @@ export class MongoDBUsersRepository implements UsersRepository {
 	constructor(@Inject("DBClient") private dbConnector: MongoDBConnector) {}
 
 	async getUserByEmail(email: string): Promise<User | null> {
-		email = email.toLowerCase();
 		const users = await this.dbConnector.users();
-		return users.findOne({ email: email }, { projection: { _id: 0, password: 0 } });
+		return users.findOne({ email: this.sanitizeEmail(email) }, { projection: MONGO_DB_USER_DEFAULT_PROJECTION });
 	}
+
 	async getUserByEmailWithPassword(email: string): Promise<User | null> {
-		email = email.toLowerCase();
 		const users = await this.dbConnector.users();
-		return users.findOne({ email: email }, { projection: { _id: 0 } });
+		return users.findOne({ email: this.sanitizeEmail(email) }, { projection: { _id: 0 } });
 	}
 
 	async addUser(createUser: CreateUserRequest): Promise<string> {
-		const newUser = createUser as User;
-		newUser.identifier = generateID();
-		newUser.permissionFlags = 1;
-		newUser.email = createUser.email.toLowerCase();
-
 		const users = await this.dbConnector.users();
+		const metadata = createMetadata();
+		const newUser: User = {
+			...createUser,
+			email: this.sanitizeEmail(createUser.email),
+			identifier: generateID(),
+			permissionFlags: 1,
+			createdAt: metadata.created,
+			updatedAt: metadata.updated,
+		};
 		await users.insertOne(newUser);
 		return newUser.identifier;
 	}
+
 	async getUsers(pagination?: Pagination): Promise<User[] | null> {
 		const users = await this.dbConnector.users();
-
 		let query = users.find({}, { projection: MONGO_DB_USER_DEFAULT_PROJECTION });
-
 		if (pagination) {
 			query = query.limit(pagination.pageSize).skip((pagination.page - 1) * pagination.pageSize);
 		}
-
 		return query.toArray();
 	}
+
 	async getUserByIdentifier(userId: string): Promise<User | null> {
 		const users = await this.dbConnector.users();
 		return users.findOne({ identifier: userId }, { projection: { _id: 0, password: 0 } });
 	}
+
 	async updateUserById(userId: string, userFields: UpdateUserRequest): Promise<boolean> {
-		if (userFields.email) userFields.email = userFields.email.toLowerCase();
+		const updatedUser: Partial<User> = {
+			...userFields,
+			email: userFields.email ? this.sanitizeEmail(userFields.email) : undefined,
+			...getUpdatedMetadata(),
+		};
 		const users = await this.dbConnector.users();
-		const result = await users.updateOne({ identifier: userId }, { $set: userFields });
+		const result = await users.updateOne({ identifier: userId }, { $set: updatedUser });
 		return result.modifiedCount === 1;
 	}
+
 	async removeUserById(userId: string): Promise<boolean> {
 		const users = await this.dbConnector.users();
 		const result = await users.deleteOne({ identifier: userId });
@@ -63,5 +72,9 @@ export class MongoDBUsersRepository implements UsersRepository {
 	async countUsers(): Promise<number> {
 		const users = await this.dbConnector.users();
 		return users.countDocuments();
+	}
+
+	private sanitizeEmail(email: string) {
+		return email.toLowerCase();
 	}
 }

--- a/src/schemas/kulturdaten.berlin.openapi.generated.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.generated.yml
@@ -1563,6 +1563,9 @@ components:
           type: string
         metadata:
           type: object
+          required:
+            - created
+            - updated
           properties:
             created:
               type: string
@@ -1570,7 +1573,9 @@ components:
               example: "2011-10-05T14:48:00.000Z"
             updated:
               type: string
-              description: The date and time the object was last updated (ISO timestamp).
+              description: >-
+                The date and time the object was last updated (ISO timestamp).
+                Is identical to created date after first creation.
               example: "2011-10-05T14:48:00.000Z"
             origin:
               type: string
@@ -1808,6 +1813,9 @@ components:
           type: string
         metadata:
           type: object
+          required:
+            - created
+            - updated
           properties:
             created:
               type: string
@@ -1815,7 +1823,9 @@ components:
               example: "2011-10-05T14:48:00.000Z"
             updated:
               type: string
-              description: The date and time the object was last updated (ISO timestamp).
+              description: >-
+                The date and time the object was last updated (ISO timestamp).
+                Is identical to created date after first creation.
               example: "2011-10-05T14:48:00.000Z"
             origin:
               type: string
@@ -1907,6 +1917,9 @@ components:
                 type: string
               metadata:
                 type: object
+                required:
+                  - created
+                  - updated
                 properties:
                   created:
                     type: string
@@ -1916,7 +1929,8 @@ components:
                     type: string
                     description: >-
                       The date and time the object was last updated (ISO
-                      timestamp).
+                      timestamp). Is identical to created date after first
+                      creation.
                     example: "2011-10-05T14:48:00.000Z"
                   origin:
                     type: string
@@ -2167,6 +2181,9 @@ components:
           type: string
         metadata:
           type: object
+          required:
+            - created
+            - updated
           properties:
             created:
               type: string
@@ -2174,7 +2191,9 @@ components:
               example: "2011-10-05T14:48:00.000Z"
             updated:
               type: string
-              description: The date and time the object was last updated (ISO timestamp).
+              description: >-
+                The date and time the object was last updated (ISO timestamp).
+                Is identical to created date after first creation.
               example: "2011-10-05T14:48:00.000Z"
             origin:
               type: string
@@ -2276,6 +2295,9 @@ components:
           type: string
         metadata:
           type: object
+          required:
+            - created
+            - updated
           properties:
             created:
               type: string
@@ -2283,7 +2305,9 @@ components:
               example: "2011-10-05T14:48:00.000Z"
             updated:
               type: string
-              description: The date and time the object was last updated (ISO timestamp).
+              description: >-
+                The date and time the object was last updated (ISO timestamp).
+                Is identical to created date after first creation.
               example: "2011-10-05T14:48:00.000Z"
             origin:
               type: string
@@ -2508,6 +2532,9 @@ components:
           type: string
         metadata:
           type: object
+          required:
+            - created
+            - updated
           properties:
             created:
               type: string
@@ -2515,7 +2542,9 @@ components:
               example: "2011-10-05T14:48:00.000Z"
             updated:
               type: string
-              description: The date and time the object was last updated (ISO timestamp).
+              description: >-
+                The date and time the object was last updated (ISO timestamp).
+                Is identical to created date after first creation.
               example: "2011-10-05T14:48:00.000Z"
             origin:
               type: string
@@ -2735,6 +2764,9 @@ components:
                   type: string
                 metadata:
                   type: object
+                  required:
+                    - created
+                    - updated
                   properties:
                     created:
                       type: string
@@ -2746,7 +2778,8 @@ components:
                       type: string
                       description: >-
                         The date and time the object was last updated (ISO
-                        timestamp).
+                        timestamp). Is identical to created date after first
+                        creation.
                       example: "2011-10-05T14:48:00.000Z"
                     origin:
                       type: string
@@ -2950,6 +2983,9 @@ components:
                         type: string
                       metadata:
                         type: object
+                        required:
+                          - created
+                          - updated
                         properties:
                           created:
                             type: string
@@ -2961,7 +2997,8 @@ components:
                             type: string
                             description: >-
                               The date and time the object was last updated (ISO
-                              timestamp).
+                              timestamp). Is identical to created date after
+                              first creation.
                             example: "2011-10-05T14:48:00.000Z"
                           origin:
                             type: string
@@ -3332,6 +3369,9 @@ components:
                         type: string
                       metadata:
                         type: object
+                        required:
+                          - created
+                          - updated
                         properties:
                           created:
                             type: string
@@ -3343,7 +3383,8 @@ components:
                             type: string
                             description: >-
                               The date and time the object was last updated (ISO
-                              timestamp).
+                              timestamp). Is identical to created date after
+                              first creation.
                             example: "2011-10-05T14:48:00.000Z"
                           origin:
                             type: string
@@ -3667,6 +3708,9 @@ components:
                         type: string
                       metadata:
                         type: object
+                        required:
+                          - created
+                          - updated
                         properties:
                           created:
                             type: string
@@ -3678,7 +3722,8 @@ components:
                             type: string
                             description: >-
                               The date and time the object was last updated (ISO
-                              timestamp).
+                              timestamp). Is identical to created date after
+                              first creation.
                             example: "2011-10-05T14:48:00.000Z"
                           origin:
                             type: string
@@ -3962,6 +4007,9 @@ components:
                         type: string
                       metadata:
                         type: object
+                        required:
+                          - created
+                          - updated
                         properties:
                           created:
                             type: string
@@ -3973,7 +4021,8 @@ components:
                             type: string
                             description: >-
                               The date and time the object was last updated (ISO
-                              timestamp).
+                              timestamp). Is identical to created date after
+                              first creation.
                             example: "2011-10-05T14:48:00.000Z"
                           origin:
                             type: string
@@ -4113,6 +4162,9 @@ components:
                   type: string
                 metadata:
                   type: object
+                  required:
+                    - created
+                    - updated
                   properties:
                     created:
                       type: string
@@ -4124,7 +4176,8 @@ components:
                       type: string
                       description: >-
                         The date and time the object was last updated (ISO
-                        timestamp).
+                        timestamp). Is identical to created date after first
+                        creation.
                       example: "2011-10-05T14:48:00.000Z"
                     origin:
                       type: string
@@ -4350,6 +4403,9 @@ components:
                         type: string
                       metadata:
                         type: object
+                        required:
+                          - created
+                          - updated
                         properties:
                           created:
                             type: string
@@ -4361,7 +4417,8 @@ components:
                             type: string
                             description: >-
                               The date and time the object was last updated (ISO
-                              timestamp).
+                              timestamp). Is identical to created date after
+                              first creation.
                             example: "2011-10-05T14:48:00.000Z"
                           origin:
                             type: string
@@ -4878,6 +4935,9 @@ components:
                         type: string
                       metadata:
                         type: object
+                        required:
+                          - created
+                          - updated
                         properties:
                           created:
                             type: string
@@ -4889,7 +4949,8 @@ components:
                             type: string
                             description: >-
                               The date and time the object was last updated (ISO
-                              timestamp).
+                              timestamp). Is identical to created date after
+                              first creation.
                             example: "2011-10-05T14:48:00.000Z"
                           origin:
                             type: string
@@ -5151,6 +5212,9 @@ components:
                   type: string
                 metadata:
                   type: object
+                  required:
+                    - created
+                    - updated
                   properties:
                     created:
                       type: string
@@ -5162,7 +5226,8 @@ components:
                       type: string
                       description: >-
                         The date and time the object was last updated (ISO
-                        timestamp).
+                        timestamp). Is identical to created date after first
+                        creation.
                       example: "2011-10-05T14:48:00.000Z"
                     origin:
                       type: string
@@ -5613,6 +5678,9 @@ components:
                         type: string
                       metadata:
                         type: object
+                        required:
+                          - created
+                          - updated
                         properties:
                           created:
                             type: string
@@ -5624,7 +5692,8 @@ components:
                             type: string
                             description: >-
                               The date and time the object was last updated (ISO
-                              timestamp).
+                              timestamp). Is identical to created date after
+                              first creation.
                             example: "2011-10-05T14:48:00.000Z"
                           origin:
                             type: string
@@ -6195,6 +6264,9 @@ components:
                         type: string
                       metadata:
                         type: object
+                        required:
+                          - created
+                          - updated
                         properties:
                           created:
                             type: string
@@ -6206,7 +6278,8 @@ components:
                             type: string
                             description: >-
                               The date and time the object was last updated (ISO
-                              timestamp).
+                              timestamp). Is identical to created date after
+                              first creation.
                             example: "2011-10-05T14:48:00.000Z"
                           origin:
                             type: string
@@ -6481,6 +6554,9 @@ components:
                   type: string
                 metadata:
                   type: object
+                  required:
+                    - created
+                    - updated
                   properties:
                     created:
                       type: string
@@ -6492,7 +6568,8 @@ components:
                       type: string
                       description: >-
                         The date and time the object was last updated (ISO
-                        timestamp).
+                        timestamp). Is identical to created date after first
+                        creation.
                       example: "2011-10-05T14:48:00.000Z"
                     origin:
                       type: string
@@ -7182,6 +7259,9 @@ components:
                   metadata:
                     allOf:
                       - type: object
+                        required:
+                          - created
+                          - updated
                         properties:
                           created:
                             type: string
@@ -7193,7 +7273,8 @@ components:
                             type: string
                             description: >-
                               The date and time the object was last updated (ISO
-                              timestamp).
+                              timestamp). Is identical to created date after
+                              first creation.
                             example: "2011-10-05T14:48:00.000Z"
                           origin:
                             type: string
@@ -7255,6 +7336,9 @@ components:
                 metadata:
                   allOf:
                     - type: object
+                      required:
+                        - created
+                        - updated
                       properties:
                         created:
                           type: string
@@ -7266,7 +7350,8 @@ components:
                           type: string
                           description: >-
                             The date and time the object was last updated (ISO
-                            timestamp).
+                            timestamp). Is identical to created date after first
+                            creation.
                           example: "2011-10-05T14:48:00.000Z"
                         origin:
                           type: string
@@ -7318,6 +7403,9 @@ components:
         metadata:
           allOf:
             - type: object
+              required:
+                - created
+                - updated
               properties:
                 created:
                   type: string
@@ -7327,7 +7415,8 @@ components:
                   type: string
                   description: >-
                     The date and time the object was last updated (ISO
-                    timestamp).
+                    timestamp). Is identical to created date after first
+                    creation.
                   example: "2011-10-05T14:48:00.000Z"
                 origin:
                   type: string
@@ -7386,6 +7475,9 @@ components:
                 metadata:
                   allOf:
                     - type: object
+                      required:
+                        - created
+                        - updated
                       properties:
                         created:
                           type: string
@@ -7397,7 +7489,8 @@ components:
                           type: string
                           description: >-
                             The date and time the object was last updated (ISO
-                            timestamp).
+                            timestamp). Is identical to created date after first
+                            creation.
                           example: "2011-10-05T14:48:00.000Z"
                         origin:
                           type: string
@@ -7454,6 +7547,9 @@ components:
                   type: string
                 metadata:
                   type: object
+                  required:
+                    - created
+                    - updated
                   properties:
                     created:
                       type: string
@@ -7465,7 +7561,8 @@ components:
                       type: string
                       description: >-
                         The date and time the object was last updated (ISO
-                        timestamp).
+                        timestamp). Is identical to created date after first
+                        creation.
                       example: "2011-10-05T14:48:00.000Z"
                     origin:
                       type: string
@@ -7557,6 +7654,9 @@ components:
                         type: string
                       metadata:
                         type: object
+                        required:
+                          - created
+                          - updated
                         properties:
                           created:
                             type: string
@@ -7568,7 +7668,8 @@ components:
                             type: string
                             description: >-
                               The date and time the object was last updated (ISO
-                              timestamp).
+                              timestamp). Is identical to created date after
+                              first creation.
                             example: "2011-10-05T14:48:00.000Z"
                           origin:
                             type: string
@@ -7866,6 +7967,9 @@ components:
                         type: string
                       metadata:
                         type: object
+                        required:
+                          - created
+                          - updated
                         properties:
                           created:
                             type: string
@@ -7877,7 +7981,8 @@ components:
                             type: string
                             description: >-
                               The date and time the object was last updated (ISO
-                              timestamp).
+                              timestamp). Is identical to created date after
+                              first creation.
                             example: "2011-10-05T14:48:00.000Z"
                           origin:
                             type: string
@@ -7971,6 +8076,9 @@ components:
                               type: string
                             metadata:
                               type: object
+                              required:
+                                - created
+                                - updated
                               properties:
                                 created:
                                   type: string
@@ -7982,7 +8090,8 @@ components:
                                   type: string
                                   description: >-
                                     The date and time the object was last
-                                    updated (ISO timestamp).
+                                    updated (ISO timestamp). Is identical to
+                                    created date after first creation.
                                   example: "2011-10-05T14:48:00.000Z"
                                 origin:
                                   type: string

--- a/src/schemas/kulturdaten.berlin.openapi.generated.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.generated.yml
@@ -7384,12 +7384,6 @@ components:
     CreateTagRequest:
       type: object
       properties:
-        type:
-          type: string
-          enum:
-            - type.Tag
-        identifier:
-          type: string
         title:
           type: object
           additionalProperties:
@@ -7401,46 +7395,11 @@ components:
             de: Konzert
             en: concert
         metadata:
-          allOf:
-            - type: object
-              required:
-                - created
-                - updated
-              properties:
-                created:
-                  type: string
-                  description: The date and time the object was created (ISO timestamp).
-                  example: "2011-10-05T14:48:00.000Z"
-                updated:
-                  type: string
-                  description: >-
-                    The date and time the object was last updated (ISO
-                    timestamp). Is identical to created date after first
-                    creation.
-                  example: "2011-10-05T14:48:00.000Z"
-                origin:
-                  type: string
-                  description: The source of this object.
-                  example: bezirkskalender
-                originObjectID:
-                  type: string
-                  description: The original ID of this object in the original system.
-                availableLanguages:
-                  type: array
-                  description: List of languages this object is available in.
-                  example:
-                    - de
-                    - en
-                  items:
-                    type: string
-            - type: object
-              properties:
-                externalIDs:
-                  type: object
-                  additionalProperties:
-                    type: string
+          type: object
+          properties:
+            externalIDs:
+              type: object
       required:
-        - identifier
         - title
     CreateTagResponse:
       properties:

--- a/src/schemas/models/CreateTagRequest.yml
+++ b/src/schemas/models/CreateTagRequest.yml
@@ -1,1 +1,11 @@
-$ref: "Tag.yml"
+type: object
+properties:
+  title:
+    $ref: "TranslatableField.yml"
+  metadata:
+    type: object
+    properties:
+      externalIDs:
+        type: object
+required:
+  - title

--- a/src/schemas/models/Metadata.yml
+++ b/src/schemas/models/Metadata.yml
@@ -1,4 +1,7 @@
 type: object
+required:
+  - created
+  - updated
 properties:
   created:
     type: string
@@ -6,7 +9,7 @@ properties:
     example: "2011-10-05T14:48:00.000Z"
   updated:
     type: string
-    description: The date and time the object was last updated (ISO timestamp).
+    description: The date and time the object was last updated (ISO timestamp). Is identical to created date after first creation.
     example: "2011-10-05T14:48:00.000Z"
   origin:
     type: string

--- a/src/scripts/seeder.ts
+++ b/src/scripts/seeder.ts
@@ -6,6 +6,7 @@ import { Command } from "commander";
 import { MongoClient } from "mongodb";
 import validator from "validator";
 import { MongoDBConnector } from "../common/services/MongoDBConnector";
+import { Tag } from "../generated/models/Tag.generated";
 import { User } from "../generated/models/User.generated";
 import { PermissionFlag } from "../resources/auth/middleware/PermissionFlag";
 import accessibilityTagsJSON from "../seed/accessibility.json";
@@ -127,7 +128,15 @@ async function addAccessibilityTags() {
 async function addTagsToDatabase(tagsData: typeof tagsJSON | typeof accessibilityTagsJSON, logMessage: string) {
 	const db = await mongoDBConnector.getDatabase();
 	const tags = db.collection("tags");
-	await tags.insertMany(tagsData);
+	const tagsToAdd: Tag[] = tagsData.map((tag) => ({
+		...tag,
+		type: "type.Tag",
+		metadata: {
+			...tag.metadata,
+			...createMetadata(),
+		},
+	}));
+	await tags.insertMany(tagsToAdd);
 
 	console.log(logMessage);
 }

--- a/src/utils/IDUtil.ts
+++ b/src/utils/IDUtil.ts
@@ -26,3 +26,7 @@ export function generateOrganizationID(): string {
 export function generateUserID(): string {
 	return "U_" + generateID();
 }
+
+export function generateTagID(): string {
+	return "T_" + generateID();
+}

--- a/src/utils/MetadataUtil.ts
+++ b/src/utils/MetadataUtil.ts
@@ -1,6 +1,6 @@
 import { Metadata } from "../generated/models/Metadata.generated";
 
-export function getCurrentTimestamp() {
+function getCurrentTimestamp() {
 	return new Date().toISOString();
 }
 

--- a/src/utils/MetadataUtil.ts
+++ b/src/utils/MetadataUtil.ts
@@ -1,6 +1,6 @@
 import { Metadata } from "../generated/models/Metadata.generated";
 
-function getCurrentTimestamp() {
+export function getCurrentTimestamp() {
 	return new Date().toISOString();
 }
 

--- a/src/utils/MetadataUtil.ts
+++ b/src/utils/MetadataUtil.ts
@@ -1,0 +1,17 @@
+import { Metadata } from "../generated/models/Metadata.generated";
+
+function formatDate(date: Date) {
+	return date.toISOString();
+}
+
+/**
+ * Creates a valid metadata object with timestamps for new and upated entities.
+ */
+export function createMetadata(existingMetadata?: Partial<Metadata>): Metadata {
+	const createdDate = formatDate(new Date());
+	return {
+		...existingMetadata,
+		created: existingMetadata?.created || createdDate,
+		updated: createdDate,
+	};
+}

--- a/src/utils/MetadataUtil.ts
+++ b/src/utils/MetadataUtil.ts
@@ -1,17 +1,26 @@
 import { Metadata } from "../generated/models/Metadata.generated";
 
-function formatDate(date: Date) {
-	return date.toISOString();
+export function getCurrentTimestamp() {
+	return new Date().toISOString();
+}
+
+/**
+ * To be used in a MongoDB update operation (e.g. via $set).
+ */
+export function getUpdatedMetadata() {
+	return {
+		"metadata.updated": getCurrentTimestamp(),
+	};
 }
 
 /**
  * Creates a valid metadata object with timestamps for new and upated entities.
  */
 export function createMetadata(existingMetadata?: Partial<Metadata>): Metadata {
-	const createdDate = formatDate(new Date());
+	const currentTimestamp = getCurrentTimestamp();
 	return {
 		...existingMetadata,
-		created: existingMetadata?.created || createdDate,
-		updated: createdDate,
+		created: existingMetadata?.created || currentTimestamp,
+		updated: currentTimestamp,
 	};
 }


### PR DESCRIPTION
This adds and improves some logic around metadata, namely timestamps for creation and update of all entities, generating identifiers on the server-side instead of using the identifier field from the request, and updating test data to match the new format.

⚠️ Branch is based off https://github.com/technologiestiftung/kulturdaten-api/pull/62

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205601447394494