### PR TITLE
fix: make date comparison in tests more lenient to fix CI test runs

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,9 +1,10 @@
+import type { Config } from "jest";
+
 /*
  * For a detailed explanation regarding each configuration property and type check, visit:
  * https://jestjs.io/docs/configuration
  */
-
-export default {
+const config: Config = {
 	// All imported modules in your tests should be mocked automatically
 	// automock: false,
 
@@ -197,3 +198,5 @@ export default {
 process.env = Object.assign(process.env, {
 	JWT_SECRET: "test-secret",
 });
+
+export default config;

--- a/src/integrationtests/AttractionsResources.integration.test.ts
+++ b/src/integrationtests/AttractionsResources.integration.test.ts
@@ -1,10 +1,9 @@
 import request from "supertest";
-
 import { fakeCreateAttractionRequest } from "../generated/faker/faker.CreateAttractionRequest.generated";
 import { Attraction, validateAttraction } from "../generated/models/Attraction.generated";
+import { getSeconds } from "../utils/test/TestUtil";
 import { TestEnvironment } from "./integrationtestutils/TestEnvironment";
 import { ATTRACTION_IDENTIFIER_REG_EX } from "./integrationtestutils/testmatcher";
-
 import threeDummyAttractions from "./testdata/attractions.json";
 
 let env!: TestEnvironment;
@@ -66,8 +65,8 @@ describe("Create attractions", () => {
 		const newAttractionID = body.data.attractionReference.referenceId;
 		const createdAttraction = await env.attractions.findOne<Attraction>({ identifier: newAttractionID });
 		const metadata = createdAttraction!.metadata!;
-		expect(metadata.created).toBe("2023-10-01T01:02:03.000Z");
-		expect(metadata.updated).toBe("2023-10-01T01:02:03.000Z");
+		expect(getSeconds(metadata.created)).toBe(getSeconds("2023-10-01T01:02:03.000Z"));
+		expect(getSeconds(metadata.updated)).toBe(getSeconds("2023-10-01T01:02:03.000Z"));
 	});
 });
 
@@ -151,7 +150,7 @@ describe("Update attractions", () => {
 		const updatedAttraction = await env.attractions.findOne<Attraction>({ identifier });
 		const metadata = updatedAttraction!.metadata;
 		expect(metadata.created).toBe(existingAttraction!.metadata!.created);
-		expect(metadata.updated).toBe("2023-10-23T01:02:03.000Z");
+		expect(getSeconds(metadata.updated)).toBe(getSeconds("2023-10-23T01:02:03.000Z"));
 	});
 
 	it("should return an error when an invalid ID is provided / PATCH /attractions/invalidID", async () => {

--- a/src/integrationtests/EventsResources.integration.test.ts
+++ b/src/integrationtests/EventsResources.integration.test.ts
@@ -6,6 +6,7 @@ import { FindEventsByLocationAccessibilityTagsFilterStrategy } from "../resource
 import { FindEventsByMongoDBFilterStrategy } from "../resources/events/filter/implementations/FindEventsByMongoDBFilterStrategy";
 import { FindInTheFutureEventsFilterStrategy } from "../resources/events/filter/implementations/FindInTheFutureEventsFilterStrategy";
 import { getStartDateAsISO } from "../utils/DateTimeUtil";
+import { getSeconds } from "../utils/test/TestUtil";
 import { TestEnvironment } from "./integrationtestutils/TestEnvironment";
 import { EVENT_IDENTIFIER_REG_EX } from "./integrationtestutils/testmatcher";
 import threeDummyAttractions from "./testdata/attractions.json";
@@ -70,8 +71,8 @@ describe("Create events", () => {
 		const newEventID = body.data.eventReference.referenceId;
 		const createdEvent = await env.events.findOne<Event>({ identifier: newEventID });
 		const metadata = createdEvent!.metadata!;
-		expect(metadata.created).toBe("2023-10-01T01:02:03.000Z");
-		expect(metadata.updated).toBe("2023-10-01T01:02:03.000Z");
+		expect(getSeconds(metadata.created)).toBe(getSeconds("2023-10-01T01:02:03.000Z"));
+		expect(getSeconds(metadata.updated)).toBe(getSeconds("2023-10-01T01:02:03.000Z"));
 	});
 });
 
@@ -172,7 +173,7 @@ describe("Update events", () => {
 		const updatedEvent = await env.events.findOne<Event>({ identifier });
 		const metadata = updatedEvent!.metadata!;
 		expect(metadata.created).toBe(existingEvent!.metadata!.created);
-		expect(metadata.updated).toBe("2023-10-23T01:02:03.000Z");
+		expect(getSeconds(metadata.updated)).toBe(getSeconds("2023-10-23T01:02:03.000Z"));
 	});
 
 	it("should return an error when an invalid ID is provided / PATCH /events/invalidID", async () => {

--- a/src/integrationtests/LocationsResources.integration.test.ts
+++ b/src/integrationtests/LocationsResources.integration.test.ts
@@ -1,10 +1,9 @@
 import request from "supertest";
-
 import { fakeCreateLocationRequest } from "../generated/faker/faker.CreateLocationRequest.generated";
 import { Location, validateLocation } from "../generated/models/Location.generated";
+import { getSeconds } from "../utils/test/TestUtil";
 import { TestEnvironment } from "./integrationtestutils/TestEnvironment";
 import { LOCATION_IDENTIFIER_REG_EX } from "./integrationtestutils/testmatcher";
-
 import dummyLocations from "./testdata/locations.json";
 
 let env!: TestEnvironment;
@@ -65,8 +64,8 @@ describe("Create locations", () => {
 		const newLocationID = body.data.locationReference.referenceId;
 		const createdLocation = await env.locations.findOne<Location>({ identifier: newLocationID });
 		const metadata = createdLocation!.metadata!;
-		expect(metadata.created).toBe("2023-10-01T01:02:03.000Z");
-		expect(metadata.updated).toBe("2023-10-01T01:02:03.000Z");
+		expect(getSeconds(metadata.created)).toBe(getSeconds("2023-10-01T01:02:03.000Z"));
+		expect(getSeconds(metadata.updated)).toBe(getSeconds("2023-10-01T01:02:03.000Z"));
 	});
 });
 
@@ -150,7 +149,7 @@ describe("Update locations", () => {
 		const updatedLocation = await env.locations.findOne<Location>({ identifier });
 		const metadata = updatedLocation!.metadata!;
 		expect(metadata.created).toBe(existingLocation!.metadata!.created);
-		expect(metadata.updated).toBe("2023-10-23T01:02:03.000Z");
+		expect(getSeconds(metadata.updated)).toBe(getSeconds("2023-10-23T01:02:03.000Z"));
 	});
 
 	it("should return an error when an invalid ID is provided / PATCH /locations/invalidID", async () => {

--- a/src/integrationtests/OrganizationsResources.integration.test.ts
+++ b/src/integrationtests/OrganizationsResources.integration.test.ts
@@ -1,10 +1,9 @@
 import request from "supertest";
-
 import { fakeCreateOrganizationRequest } from "../generated/faker/faker.CreateOrganizationRequest.generated";
 import { Organization, validateOrganization } from "../generated/models/Organization.generated";
+import { getSeconds } from "../utils/test/TestUtil";
 import { TestEnvironment } from "./integrationtestutils/TestEnvironment";
 import { ORGANIZATION_IDENTIFIER_REG_EX } from "./integrationtestutils/testmatcher";
-
 import threeDummyOrganizations from "./testdata/organizations.json";
 
 let env!: TestEnvironment;
@@ -65,8 +64,8 @@ describe("Create organizations", () => {
 		const newOrganizationID = body.data.organizationReference.referenceId;
 		const createdOrganization = await env.organizations.findOne<Organization>({ identifier: newOrganizationID });
 		const metadata = createdOrganization!.metadata!;
-		expect(metadata.created).toBe("2023-10-01T01:02:03.000Z");
-		expect(metadata.updated).toBe("2023-10-01T01:02:03.000Z");
+		expect(getSeconds(metadata.created)).toBe(getSeconds("2023-10-01T01:02:03.000Z"));
+		expect(getSeconds(metadata.updated)).toBe(getSeconds("2023-10-01T01:02:03.000Z"));
 	});
 });
 
@@ -153,7 +152,7 @@ describe("Update organizations", () => {
 		const updatedOrganization = await env.organizations.findOne<Organization>({ identifier });
 		const metadata = updatedOrganization!.metadata!;
 		expect(metadata.created).toBe(existingOrganization!.metadata!.created);
-		expect(metadata.updated).toBe("2023-10-23T01:02:03.000Z");
+		expect(getSeconds(metadata.updated)).toBe(getSeconds("2023-10-23T01:02:03.000Z"));
 	});
 
 	it("should return an error when an invalid ID is provided / PATCH /organizations/invalidID", async () => {

--- a/src/utils/test/TestUtil.test.ts
+++ b/src/utils/test/TestUtil.test.ts
@@ -1,0 +1,11 @@
+import { getSeconds } from "./TestUtil";
+
+describe("TestUtil", () => {
+	describe(getSeconds.name, () => {
+		test("returns the correct seconds for a date", () => {
+			const actual = getSeconds("2023-10-02T11:10:44.142Z");
+			const expected = 1696245044;
+			expect(actual).toBe(expected);
+		});
+	});
+});

--- a/src/utils/test/TestUtil.ts
+++ b/src/utils/test/TestUtil.ts
@@ -5,3 +5,12 @@ export function expectResponseSendIsEqual(mockesResponse: express.Response, expe
 	const [firstArg] = capture(mockesResponse.send).last();
 	expect(firstArg).toEqual(expected);
 }
+
+/**
+ * Returns the seconds since 1970-01-01T00:00:00Z for a given date string,
+ * e.g. to compare dates with a less precise granularity.
+ */
+export function getSeconds(dateString: string) {
+	const seconds = new Date(dateString).getTime() / 1000;
+	return Math.round(seconds);
+}


### PR DESCRIPTION
It [looks like](https://github.com/technologiestiftung/kulturdaten-api/actions/runs/6378587024/job/17309446927) we cannot guarantee fake times to be used on CI down to the exact millisecond, so with this we’re now comparing dates in tests on a basis of seconds, which should make the CI tests more stable.