### PR TITLE
refactor: remove displayName field

### DIFF
--- a/src/admin/districtData/services/DistrictDataMapper.ts
+++ b/src/admin/districtData/services/DistrictDataMapper.ts
@@ -26,13 +26,6 @@ export class DistrictDataMapper {
 				...(veranstaltung.event_titel_ru && { ru: veranstaltung.event_titel_ru }),
 				...(veranstaltung.event_titel_tr && { tr: veranstaltung.event_titel_tr }),
 			},
-			displayName: {
-				...(veranstaltung.event_titel_de && { de: veranstaltung.event_titel_de }),
-				...(veranstaltung.event_titel_en && { en: veranstaltung.event_titel_en }),
-				...(veranstaltung.event_titel_fr && { fr: veranstaltung.event_titel_fr }),
-				...(veranstaltung.event_titel_ru && { ru: veranstaltung.event_titel_ru }),
-				...(veranstaltung.event_titel_tr && { tr: veranstaltung.event_titel_tr }),
-			},
 			description: {
 				...(veranstaltung.event_beschreibung_de && { de: veranstaltung.event_beschreibung_de }),
 				...(veranstaltung.event_beschreibung_en && { en: veranstaltung.event_beschreibung_en }),
@@ -52,7 +45,6 @@ export class DistrictDataMapper {
 						externalLinks: [
 							{
 								...(veranstaltung.event_homepagename ? { displayName: veranstaltung.event_homepagename } : {}),
-
 								url: veranstaltung.event_homepage,
 							},
 						],
@@ -114,7 +106,6 @@ export class DistrictDataMapper {
 		return {
 			type: "type.Organization",
 			title: { de: veranstalter.name },
-			displayName: { de: veranstalter.name },
 			inLanguages: ["de"],
 			metadata: {
 				origin: "bezirkskalender",

--- a/src/admin/districtData/services/DistrictDataMapper.unit.test.ts
+++ b/src/admin/districtData/services/DistrictDataMapper.unit.test.ts
@@ -34,9 +34,6 @@ describe("DistrictDataMapper", () => {
 				title: {
 					de: "Baby-und Kindertrödel",
 				},
-				displayName: {
-					de: "Baby-und Kindertrödel",
-				},
 				description: {
 					de: "Unser Trödelmarkt bietet Gelegenheit, Spielzeug, Kinderwagen, Babybekleidung und vieles andere zu verkaufen oder günstig zu erwerben.\r\nWir stellen Tische (200 cm x 40 cm) und Bänke.\r\n\r\n\r\nOrt: Höfe der Fabrik Osloer Straße",
 				},

--- a/src/admin/districtData/services/DistrictDataService.ts
+++ b/src/admin/districtData/services/DistrictDataService.ts
@@ -121,7 +121,7 @@ export class DistrictDataService {
 				duplicateOrganizations[veranstalter.id] = {
 					referenceType: dOrganizations[0].type,
 					referenceId: dOrganizations[0].identifier,
-					referenceLabel: dOrganizations[0].displayName ? dOrganizations[0].displayName : dOrganizations[0].title,
+					referenceLabel: dOrganizations[0].title,
 				};
 			} else {
 				const createOrganizationRequests = this.mapper.mapOrganisation(veranstalter);
@@ -156,9 +156,7 @@ export class DistrictDataService {
 				duplicateLocations[veranstaltungsort.id] = {
 					referenceType: duplicatedLocations[0].type,
 					referenceId: duplicatedLocations[0].identifier,
-					referenceLabel: duplicatedLocations[0].displayName
-						? duplicatedLocations[0].displayName
-						: duplicatedLocations[0].title,
+					referenceLabel: duplicatedLocations[0].title,
 				};
 			} else {
 				const createLocationRequest = this.mapper.mapLocation(veranstaltungsort, barrierefreiheit, bezirke, tags);
@@ -196,9 +194,7 @@ export class DistrictDataService {
 				duplicateAttractions[veranstaltung.event_id] = {
 					referenceType: duplicatedAttractions[0].type,
 					referenceId: duplicatedAttractions[0].identifier,
-					referenceLabel: duplicatedAttractions[0].displayName
-						? duplicatedAttractions[0].displayName
-						: duplicatedAttractions[0].title,
+					referenceLabel: duplicatedAttractions[0].title,
 				};
 			} else {
 				const createAttractionRequest = this.mapper.mapAttraction(veranstaltung, tags);
@@ -217,9 +213,7 @@ export class DistrictDataService {
 					duplicateEvents[termin.id] = {
 						referenceType: duplicatedEvents[0].type,
 						referenceId: duplicatedEvents[0].identifier,
-						referenceLabel: duplicatedEvents[0].displayName
-							? duplicatedEvents[0].displayName
-							: duplicatedEvents[0].title,
+						referenceLabel: duplicatedEvents[0].title,
 					};
 				} else {
 					const createEventRequest = this.mapper.mapEvent(

--- a/src/integrationtests/testdata/attractions.json
+++ b/src/integrationtests/testdata/attractions.json
@@ -16,12 +16,6 @@
 			"es": "Observatorio de Skywalker",
 			"fr": "Observatoire de Skywalker"
 		},
-		"displayName": {
-			"en": "Skywalker's Observatory",
-			"de": "Skywalkers Observatorium",
-			"es": "Observatorio de Skywalker",
-			"fr": "Observatoire de Skywalker"
-		},
 		"description": {
 			"en": "Skywalker's Observatory is a state-of-the-art space observatory floating above Earth. It allows visitors to experience space like never before. Equipped with the latest telescopes and VR technologies, you can explore the galaxies, walk on distant planets, and even glimpse into other dimensions.",
 			"de": "Das Skywalkers Observatorium ist ein hochmodernes Weltraumobservatorium, das über der Erde schwebt. Es ermöglicht Besuchern, den Weltraum wie nie zuvor zu erleben. Ausgestattet mit den neuesten Teleskopen und VR-Technologien, können Sie die Galaxien erkunden, auf fernen Planeten spazieren gehen und sogar in andere Dimensionen blicken.",
@@ -60,11 +54,6 @@
 		},
 		"status": "attraction.published",
 		"title": {
-			"en": "Temporal Cultural Gateway",
-			"de": "Zeitkulturelles Tor",
-			"intergalactic": "Toru-Kiru Zima"
-		},
-		"displayName": {
 			"en": "Temporal Cultural Gateway",
 			"de": "Zeitkulturelles Tor",
 			"intergalactic": "Toru-Kiru Zima"
@@ -108,10 +97,6 @@
 			"en": "Berlin Wall VR Experience",
 			"de": "Berliner Mauer VR Erlebnis"
 		},
-		"displayName": {
-			"en": "Berlin Wall VR Experience",
-			"de": "Berliner Mauer VR Erlebnis"
-		},
 		"description": {
 			"en": "Step into history with the Berlin Wall VR Experience. Witness the Berlin Wall as it stood in 1961, and be a part of the events that led to its fall in 1989. This immersive virtual reality experience allows you to walk along the Wall, interact with historical figures, and gain a deeper understanding of the history of Berlin.",
 			"de": "Tauchen Sie ein in die Geschichte mit dem Berliner Mauer VR Erlebnis. Erleben Sie die Berliner Mauer, wie sie 1961 stand, und nehmen Sie teil an den Ereignissen, die 1989 zu ihrem Fall führten. Diese immersive Virtual-Reality-Erfahrung ermöglicht es Ihnen, entlang der Mauer zu laufen, mit historischen Persönlichkeiten zu interagieren und ein tieferes Verständnis für die Geschichte Berlins zu erlangen."
@@ -146,10 +131,6 @@
 		},
 		"status": "attraction.published",
 		"title": {
-			"de": "Metal Gig 5000",
-			"en": "Metal Gig 5000"
-		},
-		"displayName": {
 			"de": "Metal Gig 5000",
 			"en": "Metal Gig 5000"
 		},

--- a/src/integrationtests/testdata/events.json
+++ b/src/integrationtests/testdata/events.json
@@ -23,10 +23,6 @@
 			"de": "Konzert in Berlin",
 			"en": "Concert in Berlin"
 		},
-		"displayName": {
-			"de": "Großes Konzert",
-			"en": "Big Concert"
-		},
 		"description": {
 			"de": "Erleben Sie eine großartige Nacht voller Musik in Berlin.",
 			"en": "Experience a great night of music in Berlin."
@@ -106,11 +102,6 @@
 			"de": "Filmfestival in Berlin",
 			"en": "Film Festival in Berlin",
 			"fr": "Festival de film à Berlin"
-		},
-		"displayName": {
-			"de": "Berlin Filmfest",
-			"en": "Berlin Filmfest",
-			"fr": "Berlin Filmfest"
 		},
 		"description": {
 			"de": "Genießen Sie eine Auswahl an herausragenden Filmen beim Berlin Filmfestival.",
@@ -197,10 +188,6 @@
 			"de": "Technologie Expo in Berlin",
 			"en": "Technology Expo in Berlin"
 		},
-		"displayName": {
-			"de": "TechExpo Berlin",
-			"en": "TechExpo Berlin"
-		},
 		"description": {
 			"de": "Besuchen Sie die Technologie Expo in Berlin und entdecken Sie die neuesten Trends und Innovationen in der Technologiebranche.",
 			"en": "Visit the Technology Expo in Berlin and discover the latest trends and innovations in the technology industry."
@@ -277,10 +264,6 @@
 			"endTime": "23:00"
 		},
 		"title": {
-			"de": "Metal Gig 5000",
-			"en": "Metal Gig 5000"
-		},
-		"displayName": {
 			"de": "Metal Gig 5000",
 			"en": "Metal Gig 5000"
 		},

--- a/src/integrationtests/testdata/locations.json
+++ b/src/integrationtests/testdata/locations.json
@@ -14,10 +14,6 @@
 			"de": "Berliner Historisches Museum",
 			"en": "Berlin Historical Museum"
 		},
-		"displayName": {
-			"de": "Historisches Museum",
-			"en": "Historical Museum"
-		},
 		"description": {
 			"de": "Das Berliner Historische Museum bietet Einblicke in die Geschichte der Stadt Berlin.",
 			"en": "The Berlin Historical Museum offers insights into the history of the city of Berlin."
@@ -97,10 +93,6 @@
 		"title": {
 			"de": "Berliner Tiergarten",
 			"en": "Berlin Tiergarten"
-		},
-		"displayName": {
-			"de": "Tiergarten",
-			"en": "Tiergarten"
 		},
 		"description": {
 			"de": "Der Berliner Tiergarten ist einer der größten und bekanntesten Parks in Berlin, ideal für Spaziergänge, Picknicks und Erholung.",
@@ -182,10 +174,6 @@
 			"de": "U-Schacht Bühne",
 			"en": "U-Shaft Stage"
 		},
-		"displayName": {
-			"de": "U-Schacht Bühne",
-			"en": "U-Shaft Stage"
-		},
 		"description": {
 			"de": "Die U-Schacht Bühne ist ein einzigartiger Veranstaltungsort in einem alten U-Bahn-Schacht in Berlin. Hier finden kleine Konzerte, Theateraufführungen und andere Veranstaltungen statt.",
 			"en": "The U-Shaft Stage is a unique venue located in an old subway shaft in Berlin. It hosts small concerts, theater performances, and other events."
@@ -261,10 +249,6 @@
 		},
 		"status": "location.published",
 		"title": {
-			"de": "Blackland",
-			"en": "Blackland"
-		},
-		"displayName": {
 			"de": "Blackland",
 			"en": "Blackland"
 		},

--- a/src/integrationtests/testdata/organizations.json
+++ b/src/integrationtests/testdata/organizations.json
@@ -16,11 +16,6 @@
 			"en": "Berlin Art Emporium",
 			"fr": "Emporium d'Art de Berlin"
 		},
-		"displayName": {
-			"de": "Kunst-Basar",
-			"en": "Art Emporium",
-			"fr": "Emporium d'Art"
-		},
 		"description": {
 			"de": "Ein lebendiger Ort, der Künstlern Raum bietet, ihre Werke auszustellen und zu verkaufen. Workshops und Events finden regelmäßig statt.",
 			"en": "A vibrant space for artists to showcase and sell their work. Regular workshops and events are held.",
@@ -64,12 +59,6 @@
 			"en": "Berlin Literary Café",
 			"es": "Café Literario de Berlín",
 			"ru": "Литературное кафе Берлина"
-		},
-		"displayName": {
-			"de": "Literaturcafé",
-			"en": "Literary Café",
-			"es": "Café Literario",
-			"ru": "Литературное кафе"
 		},
 		"description": {
 			"de": "Ein gemütliches Café, in dem Literaturbegeisterte zusammenkommen, um Bücher zu lesen, zu diskutieren und an Lesungen teilzunehmen.",
@@ -115,11 +104,6 @@
 			"de": "Zeitreisende Kulturelle Austauschorganisation",
 			"en": "Time-Traveling Cultural Exchange Organization",
 			"intergalactic": "Tzoruk-Shi Zukal Moru-Toru"
-		},
-		"displayName": {
-			"de": "Zeitreisende Kultur",
-			"en": "Time-Traveling Culture",
-			"intergalactic": "Tzoruk Zukal"
 		},
 		"description": {
 			"de": "Eine Organisation aus dem Jahr 2350, die durch eine Zeitmaschine ins heutige Berlin gereist ist, um Menschen mit faszinierenden Kulturveranstaltungen aus der Zukunft vertraut zu machen.",

--- a/src/resources/organizations/repositories/MongoDBOrganizationsRepository.ts
+++ b/src/resources/organizations/repositories/MongoDBOrganizationsRepository.ts
@@ -71,7 +71,7 @@ export class MongoDBOrganizationsRepository implements OrganizationsRepository {
 		return {
 			referenceType: "type.Organization",
 			referenceId: newOrganization.identifier,
-			referenceLabel: newOrganization.displayName ? newOrganization.displayName : newOrganization.title,
+			referenceLabel: newOrganization.title,
 		};
 	}
 

--- a/src/schemas/kulturdaten.berlin.openapi.generated.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.generated.yml
@@ -1650,16 +1650,6 @@ components:
           example:
             de: Konzert
             en: concert
-        displayName:
-          type: object
-          additionalProperties:
-            type: string
-          description: >-
-            A string that can be translated into multiple languages, e.g. {
-            "de": "Konzert", "en": "concert" }
-          example:
-            de: Konzert
-            en: concert
         description:
           type: object
           additionalProperties:
@@ -1858,16 +1848,6 @@ components:
           example:
             de: Konzert
             en: concert
-        displayName:
-          type: object
-          additionalProperties:
-            type: string
-          description: >-
-            A string that can be translated into multiple languages, e.g. {
-            "de": "Konzert", "en": "concert" }
-          example:
-            de: Konzert
-            en: concert
         description:
           type: object
           additionalProperties:
@@ -1996,16 +1976,6 @@ components:
                     description: The time the event end, in timezone Europe/Berlin.
                     example: "22:00"
               title:
-                type: object
-                additionalProperties:
-                  type: string
-                description: >-
-                  A string that can be translated into multiple languages, e.g.
-                  { "de": "Konzert", "en": "concert" }
-                example:
-                  de: Konzert
-                  en: concert
-              displayName:
                 type: object
                 additionalProperties:
                   type: string
@@ -2224,16 +2194,6 @@ components:
           example:
             de: Konzert
             en: concert
-        displayName:
-          type: object
-          additionalProperties:
-            type: string
-          description: >-
-            A string that can be translated into multiple languages, e.g. {
-            "de": "Konzert", "en": "concert" }
-          example:
-            de: Konzert
-            en: concert
         description:
           type: object
           additionalProperties:
@@ -2331,16 +2291,6 @@ components:
             - location.unpublished
             - location.archived
         title:
-          type: object
-          additionalProperties:
-            type: string
-          description: >-
-            A string that can be translated into multiple languages, e.g. {
-            "de": "Konzert", "en": "concert" }
-          example:
-            de: Konzert
-            en: concert
-        displayName:
           type: object
           additionalProperties:
             type: string
@@ -2583,16 +2533,6 @@ components:
           example:
             de: Konzert
             en: concert
-        displayName:
-          type: object
-          additionalProperties:
-            type: string
-          description: >-
-            A string that can be translated into multiple languages, e.g. {
-            "de": "Konzert", "en": "concert" }
-          example:
-            de: Konzert
-            en: concert
         description:
           type: object
           additionalProperties:
@@ -2818,16 +2758,6 @@ components:
                   example:
                     de: Konzert
                     en: concert
-                displayName:
-                  type: object
-                  additionalProperties:
-                    type: string
-                  description: >-
-                    A string that can be translated into multiple languages,
-                    e.g. { "de": "Konzert", "en": "concert" }
-                  example:
-                    de: Konzert
-                    en: concert
                 description:
                   type: object
                   additionalProperties:
@@ -3039,16 +2969,6 @@ components:
                         example:
                           de: Konzert
                           en: concert
-                      displayName:
-                        type: object
-                        additionalProperties:
-                          type: string
-                        description: >-
-                          A string that can be translated into multiple
-                          languages, e.g. { "de": "Konzert", "en": "concert" }
-                        example:
-                          de: Konzert
-                          en: concert
                       description:
                         type: object
                         additionalProperties:
@@ -3169,16 +3089,6 @@ components:
           enum:
             - type.Organization
         title:
-          type: object
-          additionalProperties:
-            type: string
-          description: >-
-            A string that can be translated into multiple languages, e.g. {
-            "de": "Konzert", "en": "concert" }
-          example:
-            de: Konzert
-            en: concert
-        displayName:
           type: object
           additionalProperties:
             type: string
@@ -3425,16 +3335,6 @@ components:
                         example:
                           de: Konzert
                           en: concert
-                      displayName:
-                        type: object
-                        additionalProperties:
-                          type: string
-                        description: >-
-                          A string that can be translated into multiple
-                          languages, e.g. { "de": "Konzert", "en": "concert" }
-                        example:
-                          de: Konzert
-                          en: concert
                       description:
                         type: object
                         additionalProperties:
@@ -3551,16 +3451,6 @@ components:
       type: object
       properties:
         title:
-          type: object
-          additionalProperties:
-            type: string
-          description: >-
-            A string that can be translated into multiple languages, e.g. {
-            "de": "Konzert", "en": "concert" }
-          example:
-            de: Konzert
-            en: concert
-        displayName:
           type: object
           additionalProperties:
             type: string
@@ -3756,16 +3646,6 @@ components:
                         example:
                           de: Konzert
                           en: concert
-                      displayName:
-                        type: object
-                        additionalProperties:
-                          type: string
-                        description: >-
-                          A string that can be translated into multiple
-                          languages, e.g. { "de": "Konzert", "en": "concert" }
-                        example:
-                          de: Konzert
-                          en: concert
                       description:
                         type: object
                         additionalProperties:
@@ -3845,16 +3725,6 @@ components:
           enum:
             - type.Attraction
         title:
-          type: object
-          additionalProperties:
-            type: string
-          description: >-
-            A string that can be translated into multiple languages, e.g. {
-            "de": "Konzert", "en": "concert" }
-          example:
-            de: Konzert
-            en: concert
-        displayName:
           type: object
           additionalProperties:
             type: string
@@ -4055,16 +3925,6 @@ components:
                         example:
                           de: Konzert
                           en: concert
-                      displayName:
-                        type: object
-                        additionalProperties:
-                          type: string
-                        description: >-
-                          A string that can be translated into multiple
-                          languages, e.g. { "de": "Konzert", "en": "concert" }
-                        example:
-                          de: Konzert
-                          en: concert
                       description:
                         type: object
                         additionalProperties:
@@ -4208,16 +4068,6 @@ components:
                   example:
                     de: Konzert
                     en: concert
-                displayName:
-                  type: object
-                  additionalProperties:
-                    type: string
-                  description: >-
-                    A string that can be translated into multiple languages,
-                    e.g. { "de": "Konzert", "en": "concert" }
-                  example:
-                    de: Konzert
-                    en: concert
                 description:
                   type: object
                   additionalProperties:
@@ -4291,16 +4141,6 @@ components:
       type: object
       properties:
         title:
-          type: object
-          additionalProperties:
-            type: string
-          description: >-
-            A string that can be translated into multiple languages, e.g. {
-            "de": "Konzert", "en": "concert" }
-          example:
-            de: Konzert
-            en: concert
-        displayName:
           type: object
           additionalProperties:
             type: string
@@ -4444,16 +4284,6 @@ components:
                           - location.unpublished
                           - location.archived
                       title:
-                        type: object
-                        additionalProperties:
-                          type: string
-                        description: >-
-                          A string that can be translated into multiple
-                          languages, e.g. { "de": "Konzert", "en": "concert" }
-                        example:
-                          de: Konzert
-                          en: concert
-                      displayName:
                         type: object
                         additionalProperties:
                           type: string
@@ -4665,16 +4495,6 @@ components:
           enum:
             - type.Location
         title:
-          type: object
-          additionalProperties:
-            type: string
-          description: >-
-            A string that can be translated into multiple languages, e.g. {
-            "de": "Konzert", "en": "concert" }
-          example:
-            de: Konzert
-            en: concert
-        displayName:
           type: object
           additionalProperties:
             type: string
@@ -4985,16 +4805,6 @@ components:
                         example:
                           de: Konzert
                           en: concert
-                      displayName:
-                        type: object
-                        additionalProperties:
-                          type: string
-                        description: >-
-                          A string that can be translated into multiple
-                          languages, e.g. { "de": "Konzert", "en": "concert" }
-                        example:
-                          de: Konzert
-                          en: concert
                       description:
                         type: object
                         additionalProperties:
@@ -5260,16 +5070,6 @@ components:
                   example:
                     de: Konzert
                     en: concert
-                displayName:
-                  type: object
-                  additionalProperties:
-                    type: string
-                  description: >-
-                    A string that can be translated into multiple languages,
-                    e.g. { "de": "Konzert", "en": "concert" }
-                  example:
-                    de: Konzert
-                    en: concert
                 description:
                   type: object
                   additionalProperties:
@@ -5465,16 +5265,6 @@ components:
       type: object
       properties:
         title:
-          type: object
-          additionalProperties:
-            type: string
-          description: >-
-            A string that can be translated into multiple languages, e.g. {
-            "de": "Konzert", "en": "concert" }
-          example:
-            de: Konzert
-            en: concert
-        displayName:
           type: object
           additionalProperties:
             type: string
@@ -5772,16 +5562,6 @@ components:
                         example:
                           de: Konzert
                           en: concert
-                      displayName:
-                        type: object
-                        additionalProperties:
-                          type: string
-                        description: >-
-                          A string that can be translated into multiple
-                          languages, e.g. { "de": "Konzert", "en": "concert" }
-                        example:
-                          de: Konzert
-                          en: concert
                       description:
                         type: object
                         additionalProperties:
@@ -5988,16 +5768,6 @@ components:
               description: The time the event end, in timezone Europe/Berlin.
               example: "22:00"
         title:
-          type: object
-          additionalProperties:
-            type: string
-          description: >-
-            A string that can be translated into multiple languages, e.g. {
-            "de": "Konzert", "en": "concert" }
-          example:
-            de: Konzert
-            en: concert
-        displayName:
           type: object
           additionalProperties:
             type: string
@@ -6358,16 +6128,6 @@ components:
                         example:
                           de: Konzert
                           en: concert
-                      displayName:
-                        type: object
-                        additionalProperties:
-                          type: string
-                        description: >-
-                          A string that can be translated into multiple
-                          languages, e.g. { "de": "Konzert", "en": "concert" }
-                        example:
-                          de: Konzert
-                          en: concert
                       description:
                         type: object
                         additionalProperties:
@@ -6644,16 +6404,6 @@ components:
                   example:
                     de: Konzert
                     en: concert
-                displayName:
-                  type: object
-                  additionalProperties:
-                    type: string
-                  description: >-
-                    A string that can be translated into multiple languages,
-                    e.g. { "de": "Konzert", "en": "concert" }
-                  example:
-                    de: Konzert
-                    en: concert
                 description:
                   type: object
                   additionalProperties:
@@ -6813,16 +6563,6 @@ components:
       type: object
       properties:
         title:
-          type: object
-          additionalProperties:
-            type: string
-          description: >-
-            A string that can be translated into multiple languages, e.g. {
-            "de": "Konzert", "en": "concert" }
-          example:
-            de: Konzert
-            en: concert
-        displayName:
           type: object
           additionalProperties:
             type: string
@@ -7554,16 +7294,6 @@ components:
                   example:
                     de: Konzert
                     en: concert
-                displayName:
-                  type: object
-                  additionalProperties:
-                    type: string
-                  description: >-
-                    A string that can be translated into multiple languages,
-                    e.g. { "de": "Konzert", "en": "concert" }
-                  example:
-                    de: Konzert
-                    en: concert
                 description:
                   type: object
                   additionalProperties:
@@ -7698,16 +7428,6 @@ components:
                             description: The time the event end, in timezone Europe/Berlin.
                             example: "22:00"
                       title:
-                        type: object
-                        additionalProperties:
-                          type: string
-                        description: >-
-                          A string that can be translated into multiple
-                          languages, e.g. { "de": "Konzert", "en": "concert" }
-                        example:
-                          de: Konzert
-                          en: concert
-                      displayName:
                         type: object
                         additionalProperties:
                           type: string
@@ -7976,16 +7696,6 @@ components:
                         example:
                           de: Konzert
                           en: concert
-                      displayName:
-                        type: object
-                        additionalProperties:
-                          type: string
-                        description: >-
-                          A string that can be translated into multiple
-                          languages, e.g. { "de": "Konzert", "en": "concert" }
-                        example:
-                          de: Konzert
-                          en: concert
                       description:
                         type: object
                         additionalProperties:
@@ -8124,17 +7834,6 @@ components:
                                     Europe/Berlin.
                                   example: "22:00"
                             title:
-                              type: object
-                              additionalProperties:
-                                type: string
-                              description: >-
-                                A string that can be translated into multiple
-                                languages, e.g. { "de": "Konzert", "en":
-                                "concert" }
-                              example:
-                                de: Konzert
-                                en: concert
-                            displayName:
                               type: object
                               additionalProperties:
                                 type: string

--- a/src/schemas/models/AdminAttraction.yml
+++ b/src/schemas/models/AdminAttraction.yml
@@ -22,8 +22,6 @@ properties:
       - attraction.archived
   title:
     $ref: "TranslatableField.yml"
-  displayName:
-    $ref: "TranslatableField.yml"
   description:
     $ref: "TranslatableField.yml"
   pleaseNote:

--- a/src/schemas/models/Attraction.yml
+++ b/src/schemas/models/Attraction.yml
@@ -25,8 +25,6 @@ properties:
     example:
       de: Konzert
       en: concert
-  displayName:
-    $ref: "TranslatableField.yml"
   description:
     $ref: "TranslatableField.yml"
     example:

--- a/src/schemas/models/CreateAttractionRequest.yml
+++ b/src/schemas/models/CreateAttractionRequest.yml
@@ -6,8 +6,6 @@ properties:
       - type.Attraction
   title:
     $ref: "TranslatableField.yml"
-  displayName:
-    $ref: "TranslatableField.yml"
   description:
     $ref: "TranslatableField.yml"
   pleaseNote:

--- a/src/schemas/models/CreateEventRequest.yml
+++ b/src/schemas/models/CreateEventRequest.yml
@@ -8,8 +8,6 @@ properties:
     $ref: "Schedule.yml"
   title:
     $ref: "TranslatableField.yml"
-  displayName:
-    $ref: "TranslatableField.yml"
   description:
     $ref: "TranslatableField.yml"
   pleaseNote:

--- a/src/schemas/models/CreateLocationRequest.yml
+++ b/src/schemas/models/CreateLocationRequest.yml
@@ -6,8 +6,6 @@ properties:
       - type.Location
   title:
     $ref: "TranslatableField.yml"
-  displayName:
-    $ref: "TranslatableField.yml"
   description:
     $ref: "TranslatableField.yml"
   website:

--- a/src/schemas/models/CreateOrganizationRequest.yml
+++ b/src/schemas/models/CreateOrganizationRequest.yml
@@ -6,8 +6,6 @@ properties:
       - type.Organization
   title:
     $ref: "TranslatableField.yml"
-  displayName:
-    $ref: "TranslatableField.yml"
   description:
     $ref: "TranslatableField.yml"
   website:

--- a/src/schemas/models/Event.yml
+++ b/src/schemas/models/Event.yml
@@ -27,8 +27,6 @@ properties:
     $ref: "Schedule.yml"
   title:
     $ref: "TranslatableField.yml"
-  displayName:
-    $ref: "TranslatableField.yml"
   description:
     $ref: "TranslatableField.yml"
   pleaseNote:

--- a/src/schemas/models/Location.yml
+++ b/src/schemas/models/Location.yml
@@ -18,8 +18,6 @@ properties:
       - location.archived
   title:
     $ref: "TranslatableField.yml"
-  displayName:
-    $ref: "TranslatableField.yml"
   description:
     $ref: "TranslatableField.yml"
   website:

--- a/src/schemas/models/Organization.yml
+++ b/src/schemas/models/Organization.yml
@@ -24,8 +24,6 @@ properties:
       - organization.retired
   title:
     $ref: "TranslatableField.yml"
-  displayName:
-    $ref: "TranslatableField.yml"
   description:
     $ref: "TranslatableField.yml"
   website:

--- a/src/schemas/models/UpdateAttractionRequest.yml
+++ b/src/schemas/models/UpdateAttractionRequest.yml
@@ -2,8 +2,6 @@ type: object
 properties:
   title:
     $ref: "TranslatableField.yml"
-  displayName:
-    $ref: "TranslatableField.yml"
   description:
     $ref: "TranslatableField.yml"
   pleaseNote:

--- a/src/schemas/models/UpdateEventRequest.yml
+++ b/src/schemas/models/UpdateEventRequest.yml
@@ -2,8 +2,6 @@ type: object
 properties:
   title:
     $ref: "TranslatableField.yml"
-  displayName:
-    $ref: "TranslatableField.yml"
   description:
     $ref: "TranslatableField.yml"
   pleaseNote:

--- a/src/schemas/models/UpdateLocationRequest.yml
+++ b/src/schemas/models/UpdateLocationRequest.yml
@@ -2,8 +2,6 @@ type: object
 properties:
   title:
     $ref: "TranslatableField.yml"
-  displayName:
-    $ref: "TranslatableField.yml"
   description:
     $ref: "TranslatableField.yml"
   website:

--- a/src/schemas/models/UpdateOrganizationRequest.yml
+++ b/src/schemas/models/UpdateOrganizationRequest.yml
@@ -2,8 +2,6 @@ type: object
 properties:
   title:
     $ref: "TranslatableField.yml"
-  displayName:
-    $ref: "TranslatableField.yml"
   description:
     $ref: "TranslatableField.yml"
   website:

--- a/src/scripts/schema-to-interface.ts
+++ b/src/scripts/schema-to-interface.ts
@@ -72,7 +72,7 @@ async function generateInterface(className: string, rootDirectory: string) {
 
 /**
  * Removes the extra numbers from interface names.
- * example: "displayName?: TranslatableField1;" -> "displayName?: TranslatableField;"
+ * example: "title?: TranslatableField1;" -> "title?: TranslatableField;"
  */
 function cleanUpInterfaceNames(input: string) {
 	const regex = /(\s?\S+:\s*[a-z]+)(\d+)(\[?\]?;)/gi;

--- a/src/utils/ReferenceUtil.ts
+++ b/src/utils/ReferenceUtil.ts
@@ -8,7 +8,7 @@ export function generateAttractionReference(attraction: Attraction): Reference {
 	return {
 		referenceType: attraction.type ? attraction.type : "type.Attraction",
 		referenceId: attraction.identifier,
-		referenceLabel: attraction.displayName ? attraction.displayName : attraction.title,
+		referenceLabel: attraction.title,
 	};
 }
 
@@ -25,7 +25,7 @@ export function generateLocationReference(location: Location): Reference {
 	return {
 		referenceType: location.type ? location.type : "type.Location",
 		referenceId: location.identifier,
-		referenceLabel: location.displayName ? location.displayName : location.title,
+		referenceLabel: location.title,
 	};
 }
 
@@ -42,7 +42,7 @@ export function generateOrganizationReference(organization: Organization): Refer
 	return {
 		referenceType: organization.type ? organization.type : "type.Organization",
 		referenceId: organization.identifier,
-		referenceLabel: organization.displayName ? organization.displayName : organization.title,
+		referenceLabel: organization.title,
 	};
 }
 


### PR DESCRIPTION
Removes the `displayName` from all entities field for now, as decided on [Slack](https://tsbtsbtsb.slack.com/archives/C05N1AZP918/p1695903564017989).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205628552952938