### PR TITLE
feat: make request and response validation stricter

### DIFF
--- a/src/admin/districtData/services/DistrictDataMapper.ts
+++ b/src/admin/districtData/services/DistrictDataMapper.ts
@@ -18,7 +18,6 @@ import {
 export class DistrictDataMapper {
 	mapAttraction(veranstaltung: Veranstaltung, allTags: Tag[]): CreateAttractionRequest {
 		return {
-			type: "type.Attraction",
 			title: {
 				...(veranstaltung.event_titel_de && { de: veranstaltung.event_titel_de }),
 				...(veranstaltung.event_titel_en && { en: veranstaltung.event_titel_en }),
@@ -84,7 +83,6 @@ export class DistrictDataMapper {
 		organizerReference: Reference,
 	): CreateEventRequest {
 		return {
-			type: "type.Event",
 			schedule: {
 				...(termin.tag_von && { startDate: termin.tag_von }),
 				...(termin.tag_bis && { endDate: termin.tag_bis }),
@@ -104,7 +102,6 @@ export class DistrictDataMapper {
 
 	mapOrganisation(veranstalter: Veranstalter): CreateOrganizationRequest {
 		return {
-			type: "type.Organization",
 			title: { de: veranstalter.name },
 			inLanguages: ["de"],
 			metadata: {
@@ -130,7 +127,6 @@ export class DistrictDataMapper {
 		}
 
 		return {
-			type: "type.Location",
 			title: { de: veranstaltungsort.name },
 			address: {
 				...(veranstaltungsort.strasse && { streetAddress: veranstaltungsort.strasse }),

--- a/src/admin/districtData/services/DistrictDataMapper.unit.test.ts
+++ b/src/admin/districtData/services/DistrictDataMapper.unit.test.ts
@@ -72,14 +72,27 @@ describe("DistrictDataMapper", () => {
 				admission: {
 					ticketType: "ticketType.freeOfCharge",
 				},
-				attractions: [{ referenceId: "a_1" }],
-				locations: [{ referenceId: "l_1" }],
+				attractions: [
+					{
+						referenceType: "type.Attraction",
+						referenceId: "a_1",
+					},
+				],
+				locations: [
+					{
+						referenceType: "type.Location",
+						referenceId: "l_1",
+					},
+				],
 				metadata: {
 					origin: "bezirkskalender",
 					originObjectID: "847205",
 				},
 
-				organizer: { referenceId: "o_1" },
+				organizer: {
+					referenceType: "type.Organizer",
+					referenceId: "o_1",
+				},
 				schedule: {
 					endDate: "2023-10-08",
 					endTime: "00:00:00",
@@ -91,9 +104,9 @@ describe("DistrictDataMapper", () => {
 			const result = mapper.mapEvent(
 				termin,
 				veranstaltung,
-				{ referenceId: "a_1" },
-				{ referenceId: "l_1" },
-				{ referenceId: "o_1" },
+				{ referenceType: "type.Attraction", referenceId: "a_1" },
+				{ referenceType: "type.Location", referenceId: "l_1" },
+				{ referenceType: "type.Organizer", referenceId: "o_1" },
 			);
 
 			expect(result).toEqual(expectedResult);
@@ -105,9 +118,9 @@ describe("DistrictDataMapper", () => {
 			const result = mapper.mapEvent(
 				termin,
 				veranstaltung,
-				{ referenceId: "a_1" },
-				{ referenceId: "l_1" },
-				{ referenceId: "o_1" },
+				{ referenceType: "type.Attraction", referenceId: "a_1" },
+				{ referenceType: "type.Location", referenceId: "l_1" },
+				{ referenceType: "type.Organizer", referenceId: "o_1" },
 			);
 
 			const { isValid } = validateCreateEventRequest(result);

--- a/src/admin/districtData/services/DistrictDataMapper.unit.test.ts
+++ b/src/admin/districtData/services/DistrictDataMapper.unit.test.ts
@@ -30,7 +30,6 @@ describe("DistrictDataMapper", () => {
 	describe("map attraction", () => {
 		it("should correctly map Veranstaltung to CreateAttractionRequest", () => {
 			const expectedResult: CreateAttractionRequest = {
-				type: "type.Attraction",
 				title: {
 					de: "Baby-und Kindertrödel",
 				},
@@ -87,7 +86,6 @@ describe("DistrictDataMapper", () => {
 					startDate: "2023-10-08",
 					startTime: "15:00:00",
 				},
-				type: "type.Event",
 			};
 
 			const result = mapper.mapEvent(

--- a/src/integrationtests/AttractionsResources.integration.test.ts
+++ b/src/integrationtests/AttractionsResources.integration.test.ts
@@ -31,7 +31,10 @@ describe("Validate testData", () => {
 	it("should validate the test data", async () => {
 		const attractionDocuments = await env.attractions.find().toArray();
 		for (const o of attractionDocuments) {
-			expect(validateAttraction(o).isValid).toBe(true);
+			const isValid = validateAttraction(o).isValid;
+			const errors = validateAttraction(o).errors;
+			expect(isValid).toBe(true);
+			expect(errors).toHaveLength(0);
 		}
 	});
 });

--- a/src/integrationtests/AttractionsResources.integration.test.ts
+++ b/src/integrationtests/AttractionsResources.integration.test.ts
@@ -1,4 +1,5 @@
 import request from "supertest";
+import { MONGO_DB_DEFAULT_PROJECTION } from "../config/Config";
 import { fakeCreateAttractionRequest } from "../generated/faker/faker.CreateAttractionRequest.generated";
 import { Attraction, validateAttraction } from "../generated/models/Attraction.generated";
 import { getSeconds } from "../utils/test/TestUtil";
@@ -29,12 +30,10 @@ describe("Validate testData", () => {
 	});
 
 	it("should validate the test data", async () => {
-		const attractionDocuments = await env.attractions.find().toArray();
+		const attractionDocuments = await env.attractions.find({}, { projection: MONGO_DB_DEFAULT_PROJECTION }).toArray();
 		for (const o of attractionDocuments) {
 			const isValid = validateAttraction(o).isValid;
-			const errors = validateAttraction(o).errors;
 			expect(isValid).toBe(true);
-			expect(errors).toHaveLength(0);
 		}
 	});
 });

--- a/src/integrationtests/EventsResources.integration.test.ts
+++ b/src/integrationtests/EventsResources.integration.test.ts
@@ -1,4 +1,5 @@
 import request from "supertest";
+import { MONGO_DB_DEFAULT_PROJECTION } from "../config/Config";
 import { fakeCreateEventRequest } from "../generated/faker/faker.CreateEventRequest.generated";
 import { Event, validateEvent } from "../generated/models/Event.generated";
 import { FindEventsByAttractionTagFilterStrategy } from "../resources/events/filter/implementations/FindEventsByAttractionTagFilterStrategy";
@@ -36,9 +37,10 @@ describe("Validate testData", () => {
 	});
 
 	it("should validate the test data", async () => {
-		const eventDocuments = await env.events.find().toArray();
+		const eventDocuments = await env.events.find({}, { projection: MONGO_DB_DEFAULT_PROJECTION }).toArray();
 		for (const o of eventDocuments) {
-			expect(validateEvent(o).isValid).toBe(true);
+			const isValid = validateEvent(o).isValid;
+			expect(isValid).toBe(true);
 		}
 	});
 });

--- a/src/integrationtests/LocationsResources.integration.test.ts
+++ b/src/integrationtests/LocationsResources.integration.test.ts
@@ -1,4 +1,5 @@
 import request from "supertest";
+import { MONGO_DB_DEFAULT_PROJECTION } from "../config/Config";
 import { fakeCreateLocationRequest } from "../generated/faker/faker.CreateLocationRequest.generated";
 import { Location, validateLocation } from "../generated/models/Location.generated";
 import { getSeconds } from "../utils/test/TestUtil";
@@ -29,9 +30,10 @@ describe("Validate testData", () => {
 	});
 
 	it("should validate the test data", async () => {
-		const locationDocuments = await env.locations.find().toArray();
+		const locationDocuments = await env.locations.find({}, { projection: MONGO_DB_DEFAULT_PROJECTION }).toArray();
 		for (const o of locationDocuments) {
-			expect(validateLocation(o).isValid).toBe(true);
+			const isValid = validateLocation(o).isValid;
+			expect(isValid).toBe(true);
 		}
 	});
 });

--- a/src/integrationtests/OrganizationsResources.integration.test.ts
+++ b/src/integrationtests/OrganizationsResources.integration.test.ts
@@ -1,4 +1,5 @@
 import request from "supertest";
+import { MONGO_DB_DEFAULT_PROJECTION } from "../config/Config";
 import { fakeCreateOrganizationRequest } from "../generated/faker/faker.CreateOrganizationRequest.generated";
 import { Organization, validateOrganization } from "../generated/models/Organization.generated";
 import { getSeconds } from "../utils/test/TestUtil";
@@ -29,9 +30,12 @@ describe("Validate testData", () => {
 	});
 
 	it("should validate the test data", async () => {
-		const organizationDocuments = await env.organizations.find().toArray();
+		const organizationDocuments = await env.organizations
+			.find({}, { projection: MONGO_DB_DEFAULT_PROJECTION })
+			.toArray();
 		for (const o of organizationDocuments) {
-			expect(validateOrganization(o).isValid).toBe(true);
+			const isValid = validateOrganization(o).isValid;
+			expect(isValid).toBe(true);
 		}
 	});
 });

--- a/src/resources/attractions/repositories/MongoDBAttractionsRepository.ts
+++ b/src/resources/attractions/repositories/MongoDBAttractionsRepository.ts
@@ -67,10 +67,10 @@ export class MongoDBAttractionsRepository implements AttractionsRepository {
 
 	async getAttractionReferenceByIdentifier(attractionId: string): Promise<Reference | null> {
 		const attractions = await this.dbConnector.attractions();
-		return attractions.findOne(
+		return attractions.findOne<Reference>(
 			{ identifier: attractionId },
 			{ projection: getAttractionReferenceProjection() },
-		) as Reference;
+		);
 	}
 
 	async updateAttractionById(attractionId: string, attractionFields: UpdateAttractionRequest): Promise<boolean> {

--- a/src/resources/attractions/repositories/MongoDBAttractionsRepository.ts
+++ b/src/resources/attractions/repositories/MongoDBAttractionsRepository.ts
@@ -48,6 +48,7 @@ export class MongoDBAttractionsRepository implements AttractionsRepository {
 	async addAttraction(createAttraction: CreateAttractionRequest): Promise<Reference | null> {
 		const newAttraction: Attraction = {
 			...createAttraction,
+			type: "type.Attraction",
 			identifier: generateAttractionID(),
 			metadata: createMetadata(createAttraction.metadata),
 		};

--- a/src/resources/events/repositories/MongoDBEventsRepository.ts
+++ b/src/resources/events/repositories/MongoDBEventsRepository.ts
@@ -57,6 +57,7 @@ export class MongoDBEventsRepository implements EventsRepository {
 	async addEvent(createEvent: CreateEventRequest): Promise<Reference | null> {
 		const newEvent: Event = {
 			...createEvent,
+			type: "type.Event",
 			identifier: generateEventID(),
 			metadata: createMetadata(createEvent.metadata),
 		};

--- a/src/resources/events/repositories/MongoDBEventsRepository.ts
+++ b/src/resources/events/repositories/MongoDBEventsRepository.ts
@@ -51,7 +51,7 @@ export class MongoDBEventsRepository implements EventsRepository {
 	}
 
 	async getEventsAsReferences(pagination?: Pagination): Promise<Reference[]> {
-		return this.get(undefined, getEventReferenceProjection(), pagination) as Promise<Reference[]>;
+		return this.get(undefined, getEventReferenceProjection(), pagination) as unknown as Promise<Reference[]>;
 	}
 
 	async addEvent(createEvent: CreateEventRequest): Promise<Reference | null> {
@@ -76,7 +76,7 @@ export class MongoDBEventsRepository implements EventsRepository {
 
 	async getEventReferenceByIdentifier(eventId: string): Promise<Reference | null> {
 		const events = await this.dbConnector.events();
-		return events.findOne({ identifier: eventId }, { projection: getEventReferenceProjection() }) as Reference;
+		return events.findOne<Reference>({ identifier: eventId }, { projection: getEventReferenceProjection() });
 	}
 
 	private async saveUpdatedEvent(eventId: string, updatedEvent: MatchKeysAndValues<Event>) {

--- a/src/resources/events/services/EventsService.ts
+++ b/src/resources/events/services/EventsService.ts
@@ -111,7 +111,7 @@ export class EventsService {
 	}
 
 	addEventLocation(identifier: string, addEventLocationRequest: AddEventLocationRequest): Promise<boolean> {
-		const reference = {
+		const reference: Reference = {
 			referenceType: "type.Location",
 			referenceId: addEventLocationRequest.locationIdentifier,
 			referenceLabel: addEventLocationRequest.alternativeDisplayName,
@@ -124,7 +124,7 @@ export class EventsService {
 	}
 
 	addEventAttraction(identifier: string, addEventAttractionRequest: AddEventAttractionRequest): Promise<boolean> {
-		const reference = {
+		const reference: Reference = {
 			referenceType: "type.Attraction",
 			referenceId: addEventAttractionRequest.attractionIdentifier,
 			referenceLabel: addEventAttractionRequest.alternativeDisplayName,
@@ -140,7 +140,7 @@ export class EventsService {
 	}
 
 	setEventOrganizer(identifier: string, setEventOrganizerRequest: SetEventOrganizerRequest): Promise<boolean> {
-		const reference = {
+		const reference: Reference = {
 			referenceType: "type.Organizer",
 			referenceId: setEventOrganizerRequest.organizationIdentifier,
 			referenceLabel: setEventOrganizerRequest.alternativeDisplayName,

--- a/src/resources/events/services/EventsService.unit.test.ts
+++ b/src/resources/events/services/EventsService.unit.test.ts
@@ -7,17 +7,21 @@ describe("test intersection and removeDuplicates", () => {
 	it(" should return the intersection of two event arrays ", async () => {
 		const eventsA: Event[] = [
 			{
+				type: "type.Event",
 				identifier: "1",
 			},
 			{
+				type: "type.Event",
 				identifier: "2",
 			},
 		];
 		const eventsB: Event[] = [
 			{
+				type: "type.Event",
 				identifier: "2",
 			},
 			{
+				type: "type.Event",
 				identifier: "3",
 			},
 		];
@@ -26,6 +30,7 @@ describe("test intersection and removeDuplicates", () => {
 
 		expect(eventService.getIntersection(eventsA, eventsB)).toStrictEqual([
 			{
+				type: "type.Event",
 				identifier: "2",
 			},
 		]);
@@ -34,17 +39,21 @@ describe("test intersection and removeDuplicates", () => {
 	it(" should return all events without duplicates", async () => {
 		const eventsA: Event[] = [
 			{
+				type: "type.Event",
 				identifier: "1",
 			},
 			{
+				type: "type.Event",
 				identifier: "2",
 			},
 		];
 		const eventsB: Event[] = [
 			{
+				type: "type.Event",
 				identifier: "2",
 			},
 			{
+				type: "type.Event",
 				identifier: "3",
 			},
 		];
@@ -53,12 +62,15 @@ describe("test intersection and removeDuplicates", () => {
 
 		expect(eventService.removeDuplicates([...eventsA, ...eventsB])).toStrictEqual([
 			{
+				type: "type.Event",
 				identifier: "1",
 			},
 			{
+				type: "type.Event",
 				identifier: "2",
 			},
 			{
+				type: "type.Event",
 				identifier: "3",
 			},
 		]);
@@ -67,17 +79,21 @@ describe("test intersection and removeDuplicates", () => {
 	it(' MatchMode "any" should return all events without duplicates', async () => {
 		const eventsA: Event[] = [
 			{
+				type: "type.Event",
 				identifier: "1",
 			},
 			{
+				type: "type.Event",
 				identifier: "2",
 			},
 		];
 		const eventsB: Event[] = [
 			{
+				type: "type.Event",
 				identifier: "2",
 			},
 			{
+				type: "type.Event",
 				identifier: "3",
 			},
 		];
@@ -86,12 +102,15 @@ describe("test intersection and removeDuplicates", () => {
 
 		expect(eventService.match(eventsA, eventsB, "any")).toStrictEqual([
 			{
+				type: "type.Event",
 				identifier: "1",
 			},
 			{
+				type: "type.Event",
 				identifier: "2",
 			},
 			{
+				type: "type.Event",
 				identifier: "3",
 			},
 		]);
@@ -100,17 +119,21 @@ describe("test intersection and removeDuplicates", () => {
 	it(' MatchMode "all" should return the intersection of two event arrays ', async () => {
 		const eventsA: Event[] = [
 			{
+				type: "type.Event",
 				identifier: "1",
 			},
 			{
+				type: "type.Event",
 				identifier: "2",
 			},
 		];
 		const eventsB: Event[] = [
 			{
+				type: "type.Event",
 				identifier: "2",
 			},
 			{
+				type: "type.Event",
 				identifier: "3",
 			},
 		];
@@ -119,6 +142,7 @@ describe("test intersection and removeDuplicates", () => {
 
 		expect(eventService.match(eventsA, eventsB, "all")).toStrictEqual([
 			{
+				type: "type.Event",
 				identifier: "2",
 			},
 		]);

--- a/src/resources/events/services/EventsService.unit.test.ts
+++ b/src/resources/events/services/EventsService.unit.test.ts
@@ -2,6 +2,12 @@ import { mock } from "ts-mockito";
 import { Event } from "../../../generated/models/Event.generated";
 import { EventsRepository } from "../repositories/EventsRepository";
 import { EventsService } from "./EventsService";
+import { Metadata } from "../../../generated/models/Metadata.generated";
+
+const fakeMetadata: Metadata = {
+	created: "2023-10-02T15:33:41.146Z",
+	updated: "2023-10-02T15:33:41.146Z",
+};
 
 describe("test intersection and removeDuplicates", () => {
 	it(" should return the intersection of two event arrays ", async () => {
@@ -9,20 +15,24 @@ describe("test intersection and removeDuplicates", () => {
 			{
 				type: "type.Event",
 				identifier: "1",
+				metadata: fakeMetadata,
 			},
 			{
 				type: "type.Event",
 				identifier: "2",
+				metadata: fakeMetadata,
 			},
 		];
 		const eventsB: Event[] = [
 			{
 				type: "type.Event",
 				identifier: "2",
+				metadata: fakeMetadata,
 			},
 			{
 				type: "type.Event",
 				identifier: "3",
+				metadata: fakeMetadata,
 			},
 		];
 
@@ -32,6 +42,7 @@ describe("test intersection and removeDuplicates", () => {
 			{
 				type: "type.Event",
 				identifier: "2",
+				metadata: fakeMetadata,
 			},
 		]);
 	});
@@ -41,20 +52,24 @@ describe("test intersection and removeDuplicates", () => {
 			{
 				type: "type.Event",
 				identifier: "1",
+				metadata: fakeMetadata,
 			},
 			{
 				type: "type.Event",
 				identifier: "2",
+				metadata: fakeMetadata,
 			},
 		];
 		const eventsB: Event[] = [
 			{
 				type: "type.Event",
 				identifier: "2",
+				metadata: fakeMetadata,
 			},
 			{
 				type: "type.Event",
 				identifier: "3",
+				metadata: fakeMetadata,
 			},
 		];
 
@@ -64,14 +79,17 @@ describe("test intersection and removeDuplicates", () => {
 			{
 				type: "type.Event",
 				identifier: "1",
+				metadata: fakeMetadata,
 			},
 			{
 				type: "type.Event",
 				identifier: "2",
+				metadata: fakeMetadata,
 			},
 			{
 				type: "type.Event",
 				identifier: "3",
+				metadata: fakeMetadata,
 			},
 		]);
 	});
@@ -81,20 +99,24 @@ describe("test intersection and removeDuplicates", () => {
 			{
 				type: "type.Event",
 				identifier: "1",
+				metadata: fakeMetadata,
 			},
 			{
 				type: "type.Event",
 				identifier: "2",
+				metadata: fakeMetadata,
 			},
 		];
 		const eventsB: Event[] = [
 			{
 				type: "type.Event",
 				identifier: "2",
+				metadata: fakeMetadata,
 			},
 			{
 				type: "type.Event",
 				identifier: "3",
+				metadata: fakeMetadata,
 			},
 		];
 
@@ -104,14 +126,17 @@ describe("test intersection and removeDuplicates", () => {
 			{
 				type: "type.Event",
 				identifier: "1",
+				metadata: fakeMetadata,
 			},
 			{
 				type: "type.Event",
 				identifier: "2",
+				metadata: fakeMetadata,
 			},
 			{
 				type: "type.Event",
 				identifier: "3",
+				metadata: fakeMetadata,
 			},
 		]);
 	});
@@ -121,20 +146,24 @@ describe("test intersection and removeDuplicates", () => {
 			{
 				type: "type.Event",
 				identifier: "1",
+				metadata: fakeMetadata,
 			},
 			{
 				type: "type.Event",
 				identifier: "2",
+				metadata: fakeMetadata,
 			},
 		];
 		const eventsB: Event[] = [
 			{
 				type: "type.Event",
 				identifier: "2",
+				metadata: fakeMetadata,
 			},
 			{
 				type: "type.Event",
 				identifier: "3",
+				metadata: fakeMetadata,
 			},
 		];
 
@@ -144,6 +173,7 @@ describe("test intersection and removeDuplicates", () => {
 			{
 				type: "type.Event",
 				identifier: "2",
+				metadata: fakeMetadata,
 			},
 		]);
 	});

--- a/src/resources/locations/repositories/MongoDBLocationsRepository.ts
+++ b/src/resources/locations/repositories/MongoDBLocationsRepository.ts
@@ -43,6 +43,7 @@ export class MongoDBLocationsRepository implements LocationsRepository {
 		const locations = await this.dbConnector.locations();
 		const newLocation: Location = {
 			...createLocation,
+			type: "type.Location",
 			identifier: generateLocationID(),
 			metadata: createMetadata(createLocation.metadata),
 		};

--- a/src/resources/locations/repositories/MongoDBLocationsRepository.ts
+++ b/src/resources/locations/repositories/MongoDBLocationsRepository.ts
@@ -60,12 +60,12 @@ export class MongoDBLocationsRepository implements LocationsRepository {
 
 	async getLocationByIdentifier(locationId: string): Promise<Location | null> {
 		const locations = await this.dbConnector.locations();
-		return locations.findOne({ identifier: locationId }, { projection: { _id: 0 } });
+		return locations.findOne<Location>({ identifier: locationId }, { projection: { _id: 0 } });
 	}
 
 	async getLocationReferenceByIdentifier(locationId: string): Promise<Reference | null> {
 		const locations = await this.dbConnector.locations();
-		return locations.findOne({ identifier: locationId }, { projection: getLocationReferenceProjection() }) as Reference;
+		return locations.findOne<Reference>({ identifier: locationId }, { projection: getLocationReferenceProjection() });
 	}
 
 	async updateLocationById(locationId: string, locationFields: UpdateLocationRequest): Promise<boolean> {

--- a/src/resources/organizations/repositories/MongoDBOrganizationsRepository.ts
+++ b/src/resources/organizations/repositories/MongoDBOrganizationsRepository.ts
@@ -51,10 +51,10 @@ export class MongoDBOrganizationsRepository implements OrganizationsRepository {
 
 	async getOrganizationReferenceByIdentifier(identifier: string): Promise<Reference | null> {
 		const organizations = await this.dbConnector.organizations();
-		return organizations.findOne(
+		return organizations.findOne<Reference>(
 			{ identifier: identifier },
 			{ projection: getOrganizationReferenceProjection() },
-		) as Reference;
+		);
 	}
 
 	async addOrganization(createOrganization: CreateOrganizationRequest): Promise<Reference | null> {

--- a/src/resources/organizations/repositories/MongoDBOrganizationsRepository.ts
+++ b/src/resources/organizations/repositories/MongoDBOrganizationsRepository.ts
@@ -60,6 +60,7 @@ export class MongoDBOrganizationsRepository implements OrganizationsRepository {
 	async addOrganization(createOrganization: CreateOrganizationRequest): Promise<Reference | null> {
 		const newOrganization: Organization = {
 			...createOrganization,
+			type: "type.Organization",
 			identifier: generateOrganizationID(),
 			metadata: createMetadata(createOrganization.metadata),
 		};

--- a/src/resources/tags/repositories/MongoDBTagsRepository.ts
+++ b/src/resources/tags/repositories/MongoDBTagsRepository.ts
@@ -35,6 +35,7 @@ export class MongoDBTagsRepository implements TagsRepository {
 		const tags = await this.dbConnector.tags();
 		const newTag: Tag = {
 			...createTagRequest,
+			type: "type.Tag",
 			identifier: generateTagID(),
 			metadata: {
 				...createTagRequest.metadata,

--- a/src/resources/users/repositories/MongoDBUsersRepository.ts
+++ b/src/resources/users/repositories/MongoDBUsersRepository.ts
@@ -29,6 +29,7 @@ export class MongoDBUsersRepository implements UsersRepository {
 		const newUser: User = {
 			...createUser,
 			email: this.sanitizeEmail(createUser.email),
+			type: "User",
 			identifier: generateID(),
 			permissionFlags: 1,
 			createdAt: metadata.created,

--- a/src/schemas/kulturdaten.berlin.openapi.generated.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.generated.yml
@@ -1512,6 +1512,10 @@ components:
           example:
             de: Konzert
             en: concert
+      required:
+        - referenceType
+        - referenceId
+      additionalProperties: false
     Response:
       type: object
       properties:
@@ -1530,8 +1534,10 @@ components:
               type: string
             details:
               type: string
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     Error:
       type: object
       properties:
@@ -1541,6 +1547,7 @@ components:
           type: string
         details:
           type: string
+      additionalProperties: false
     NotFoundError:
       type: object
       properties:
@@ -1550,11 +1557,9 @@ components:
           type: string
         details:
           type: string
+      additionalProperties: false
     Event:
       type: object
-      required:
-        - type
-        - identifier
       properties:
         type:
           type: string
@@ -1564,9 +1569,6 @@ components:
           type: string
         metadata:
           type: object
-          required:
-            - created
-            - updated
           properties:
             created:
               type: string
@@ -1593,6 +1595,10 @@ components:
                 - en
               items:
                 type: string
+          required:
+            - created
+            - updated
+          additionalProperties: false
         status:
           type: string
           enum:
@@ -1641,6 +1647,7 @@ components:
               type: string
               description: The time the event end, in timezone Europe/Berlin.
               example: "22:00"
+          additionalProperties: false
         title:
           type: object
           additionalProperties:
@@ -1705,6 +1712,10 @@ components:
                 example:
                   de: Konzert
                   en: concert
+            required:
+              - referenceType
+              - referenceId
+            additionalProperties: false
         attractions:
           type: array
           items:
@@ -1724,6 +1735,10 @@ components:
                 example:
                   de: Konzert
                   en: concert
+            required:
+              - referenceType
+              - referenceId
+            additionalProperties: false
         organizer:
           type: object
           properties:
@@ -1741,6 +1756,10 @@ components:
               example:
                 de: Konzert
                 en: concert
+          required:
+            - referenceType
+            - referenceId
+          additionalProperties: false
         contact:
           type: object
           description: >-
@@ -1759,6 +1778,7 @@ components:
               type: string
               description: Phone number of the contact person.
               example: +49 30 12345678
+          additionalProperties: false
         admission:
           type: object
           description: Information about the admission to the event/attraction.
@@ -1787,14 +1807,14 @@ components:
             admissionLink:
               type: string
               example: https://example.com/
-    AdminAttraction:
-      type: object
+          additionalProperties: false
       required:
         - type
         - identifier
         - metadata
-        - title
-        - events
+      additionalProperties: false
+    AdminAttraction:
+      type: object
       properties:
         type:
           type: string
@@ -1804,9 +1824,6 @@ components:
           type: string
         metadata:
           type: object
-          required:
-            - created
-            - updated
           properties:
             created:
               type: string
@@ -1833,6 +1850,10 @@ components:
                 - en
               items:
                 type: string
+          required:
+            - created
+            - updated
+          additionalProperties: false
         status:
           type: string
           enum:
@@ -1887,9 +1908,6 @@ components:
           type: array
           items:
             type: object
-            required:
-              - type
-              - identifier
             properties:
               type:
                 type: string
@@ -1899,9 +1917,6 @@ components:
                 type: string
               metadata:
                 type: object
-                required:
-                  - created
-                  - updated
                 properties:
                   created:
                     type: string
@@ -1929,6 +1944,10 @@ components:
                       - en
                     items:
                       type: string
+                required:
+                  - created
+                  - updated
+                additionalProperties: false
               status:
                 type: string
                 enum:
@@ -1977,6 +1996,7 @@ components:
                     type: string
                     description: The time the event end, in timezone Europe/Berlin.
                     example: "22:00"
+                additionalProperties: false
               title:
                 type: object
                 additionalProperties:
@@ -2041,6 +2061,10 @@ components:
                       example:
                         de: Konzert
                         en: concert
+                  required:
+                    - referenceType
+                    - referenceId
+                  additionalProperties: false
               attractions:
                 type: array
                 items:
@@ -2060,6 +2084,10 @@ components:
                       example:
                         de: Konzert
                         en: concert
+                  required:
+                    - referenceType
+                    - referenceId
+                  additionalProperties: false
               organizer:
                 type: object
                 properties:
@@ -2077,6 +2105,10 @@ components:
                     example:
                       de: Konzert
                       en: concert
+                required:
+                  - referenceType
+                  - referenceId
+                additionalProperties: false
               contact:
                 type: object
                 description: >-
@@ -2095,6 +2127,7 @@ components:
                     type: string
                     description: Phone number of the contact person.
                     example: +49 30 12345678
+                additionalProperties: false
               admission:
                 type: object
                 description: Information about the admission to the event/attraction.
@@ -2123,6 +2156,12 @@ components:
                   admissionLink:
                     type: string
                     example: https://example.com/
+                additionalProperties: false
+            required:
+              - type
+              - identifier
+              - metadata
+            additionalProperties: false
         externalLinks:
           type: array
           description: Links to external resources related to this object.
@@ -2137,13 +2176,16 @@ components:
                 example: https://example.com/
             required:
               - url
-    Attraction:
-      type: object
+            additionalProperties: false
       required:
         - type
         - identifier
         - metadata
         - title
+        - events
+      additionalProperties: false
+    Attraction:
+      type: object
       properties:
         type:
           type: string
@@ -2153,9 +2195,6 @@ components:
           type: string
         metadata:
           type: object
-          required:
-            - created
-            - updated
           properties:
             created:
               type: string
@@ -2182,6 +2221,10 @@ components:
                 - en
               items:
                 type: string
+          required:
+            - created
+            - updated
+          additionalProperties: false
         status:
           type: string
           enum:
@@ -2244,11 +2287,15 @@ components:
                 example: https://example.com/
             required:
               - url
-    Location:
-      type: object
+            additionalProperties: false
       required:
         - type
         - identifier
+        - metadata
+        - title
+      additionalProperties: false
+    Location:
+      type: object
       properties:
         type:
           type: string
@@ -2258,9 +2305,6 @@ components:
           type: string
         metadata:
           type: object
-          required:
-            - created
-            - updated
           properties:
             created:
               type: string
@@ -2287,6 +2331,10 @@ components:
                 - en
               items:
                 type: string
+          required:
+            - created
+            - updated
+          additionalProperties: false
         status:
           type: string
           enum:
@@ -2332,6 +2380,7 @@ components:
             description:
               type: string
               example: Main hall
+          additionalProperties: false
         borough:
           type: string
           description: >-
@@ -2364,6 +2413,10 @@ components:
               type: string
               enum:
                 - WGS84 (Decimal Degrees)
+          required:
+            - latitude
+            - longitude
+          additionalProperties: false
         openingStatus:
           type: string
           enum:
@@ -2375,12 +2428,6 @@ components:
           items:
             type: object
             properties:
-              closes:
-                type: string
-                description: >-
-                  The closing hour of the place or service on the given day(s)
-                  of the week.
-                example: "22:00"
               dayOfWeek:
                 type: string
                 enum:
@@ -2395,9 +2442,15 @@ components:
               opens:
                 type: string
                 description: >-
-                  The opening hour of the place or service on the given day(s)
-                  of the week.
+                  The opening hour of the place or service on the given day of
+                  the week.
                 example: "12:00"
+              closes:
+                type: string
+                description: >-
+                  The closing hour of the place or service on the given day of
+                  the week.
+                example: "22:00"
               validFrom:
                 type: string
                 description: The date when the item becomes valid.
@@ -2406,6 +2459,11 @@ components:
                 description: >-
                   The date after when the item is not valid. For example the end
                   of an offer, salary period, or a period of opening hours.
+            required:
+              - dayOfWeek
+              - opens
+              - closes
+            additionalProperties: false
         inLanguages:
           type: array
           description: List of languages this object is available in.
@@ -2438,6 +2496,7 @@ components:
                   example: https://example.com/
               required:
                 - url
+              additionalProperties: false
         manager:
           type: object
           properties:
@@ -2455,6 +2514,10 @@ components:
               example:
                 de: Konzert
                 en: concert
+          required:
+            - referenceType
+            - referenceId
+          additionalProperties: false
           description: The managing person of this location.
         contact:
           type: object
@@ -2472,11 +2535,15 @@ components:
               type: string
               description: Phone number of the contact person.
               example: +49 30 12345678
-    Organization:
-      type: object
+          additionalProperties: false
       required:
         - type
         - identifier
+        - metadata
+        - title
+      additionalProperties: false
+    Organization:
+      type: object
       properties:
         type:
           type: string
@@ -2486,9 +2553,6 @@ components:
           type: string
         metadata:
           type: object
-          required:
-            - created
-            - updated
           properties:
             created:
               type: string
@@ -2515,6 +2579,10 @@ components:
                 - en
               items:
                 type: string
+          required:
+            - created
+            - updated
+          additionalProperties: false
         status:
           type: string
           enum:
@@ -2578,6 +2646,7 @@ components:
             description:
               type: string
               example: Main hall
+          additionalProperties: false
         borough:
           type: string
           description: >-
@@ -2610,6 +2679,10 @@ components:
               type: string
               enum:
                 - WGS84 (Decimal Degrees)
+          required:
+            - latitude
+            - longitude
+          additionalProperties: false
         contact:
           type: object
           description: >-
@@ -2628,6 +2701,13 @@ components:
               type: string
               description: Phone number of the contact person.
               example: +49 30 12345678
+          additionalProperties: false
+      required:
+        - type
+        - identifier
+        - metadata
+        - title
+      additionalProperties: false
     User:
       type: object
       properties:
@@ -2652,9 +2732,13 @@ components:
         permissionFlags:
           type: number
       required:
+        - type
         - identifier
         - email
+        - createdAt
+        - updatedAt
         - permissionFlags
+      additionalProperties: false
     UpdateUserPasswordRequest:
       type: object
       properties:
@@ -2662,6 +2746,10 @@ components:
           type: string
         newPassword:
           type: string
+      required:
+        - oneTimeCode
+        - newPassword
+      additionalProperties: false
     HealthResponse:
       type: object
       properties:
@@ -2676,6 +2764,10 @@ components:
                 type: string
               healthy:
                 type: boolean
+            additionalProperties: false
+      required:
+        - healthy
+      additionalProperties: false
     AddExternalLinkRequest:
       type: object
       properties:
@@ -2685,6 +2777,7 @@ components:
           type: string
       required:
         - url
+      additionalProperties: false
     GetOrganizationResponse:
       type: object
       properties:
@@ -2697,9 +2790,6 @@ components:
           properties:
             organization:
               type: object
-              required:
-                - type
-                - identifier
               properties:
                 type:
                   type: string
@@ -2709,9 +2799,6 @@ components:
                   type: string
                 metadata:
                   type: object
-                  required:
-                    - created
-                    - updated
                   properties:
                     created:
                       type: string
@@ -2741,6 +2828,10 @@ components:
                         - en
                       items:
                         type: string
+                  required:
+                    - created
+                    - updated
+                  additionalProperties: false
                 status:
                   type: string
                   enum:
@@ -2804,6 +2895,7 @@ components:
                     description:
                       type: string
                       example: Main hall
+                  additionalProperties: false
                 borough:
                   type: string
                   description: >-
@@ -2836,6 +2928,10 @@ components:
                       type: string
                       enum:
                         - WGS84 (Decimal Degrees)
+                  required:
+                    - latitude
+                    - longitude
+                  additionalProperties: false
                 contact:
                   type: object
                   description: >-
@@ -2854,6 +2950,13 @@ components:
                       type: string
                       description: Phone number of the contact person.
                       example: +49 30 12345678
+                  additionalProperties: false
+              required:
+                - type
+                - identifier
+                - metadata
+                - title
+              additionalProperties: false
             organizationReference:
               type: object
               properties:
@@ -2871,8 +2974,14 @@ components:
                   example:
                     de: Konzert
                     en: concert
+              required:
+                - referenceType
+                - referenceId
+              additionalProperties: false
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     GetOrganizationsResponse:
       type: object
       properties:
@@ -2907,9 +3016,6 @@ components:
                   type: array
                   items:
                     type: object
-                    required:
-                      - type
-                      - identifier
                     properties:
                       type:
                         type: string
@@ -2919,9 +3025,6 @@ components:
                         type: string
                       metadata:
                         type: object
-                        required:
-                          - created
-                          - updated
                         properties:
                           created:
                             type: string
@@ -2953,6 +3056,10 @@ components:
                               - en
                             items:
                               type: string
+                        required:
+                          - created
+                          - updated
+                        additionalProperties: false
                       status:
                         type: string
                         enum:
@@ -3016,6 +3123,7 @@ components:
                           description:
                             type: string
                             example: Main hall
+                        additionalProperties: false
                       borough:
                         type: string
                         description: >-
@@ -3048,6 +3156,10 @@ components:
                             type: string
                             enum:
                               - WGS84 (Decimal Degrees)
+                        required:
+                          - latitude
+                          - longitude
+                        additionalProperties: false
                       contact:
                         type: object
                         description: >-
@@ -3066,6 +3178,13 @@ components:
                             type: string
                             description: Phone number of the contact person.
                             example: +49 30 12345678
+                        additionalProperties: false
+                    required:
+                      - type
+                      - identifier
+                      - metadata
+                      - title
+                    additionalProperties: false
                 organizationsReferences:
                   type: array
                   items:
@@ -3085,8 +3204,13 @@ components:
                         example:
                           de: Konzert
                           en: concert
+                    required:
+                      - referenceType
+                      - referenceId
+                    additionalProperties: false
       required:
         - success
+      additionalProperties: false
     CreateOrganizationRequest:
       type: object
       properties:
@@ -3140,6 +3264,7 @@ components:
             description:
               type: string
               example: Main hall
+          additionalProperties: false
         borough:
           type: string
           description: >-
@@ -3172,6 +3297,10 @@ components:
               type: string
               enum:
                 - WGS84 (Decimal Degrees)
+          required:
+            - latitude
+            - longitude
+          additionalProperties: false
         contact:
           type: object
           description: >-
@@ -3190,6 +3319,7 @@ components:
               type: string
               description: Phone number of the contact person.
               example: +49 30 12345678
+          additionalProperties: false
         metadata:
           type: object
           properties:
@@ -3197,8 +3327,10 @@ components:
               type: string
             originObjectID:
               type: string
+          additionalProperties: false
       required:
         - title
+      additionalProperties: false
     CreateOrganizationResponse:
       properties:
         success:
@@ -3227,14 +3359,21 @@ components:
                   example:
                     de: Konzert
                     en: concert
+              required:
+                - referenceType
+                - referenceId
+              additionalProperties: false
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     SearchOrganizationsRequest:
       type: object
       properties:
         searchFilter:
           type: object
           additionalProperties: true
+      additionalProperties: false
     SearchOrganizationsResponse:
       type: object
       properties:
@@ -3269,9 +3408,6 @@ components:
                   type: array
                   items:
                     type: object
-                    required:
-                      - type
-                      - identifier
                     properties:
                       type:
                         type: string
@@ -3281,9 +3417,6 @@ components:
                         type: string
                       metadata:
                         type: object
-                        required:
-                          - created
-                          - updated
                         properties:
                           created:
                             type: string
@@ -3315,6 +3448,10 @@ components:
                               - en
                             items:
                               type: string
+                        required:
+                          - created
+                          - updated
+                        additionalProperties: false
                       status:
                         type: string
                         enum:
@@ -3378,6 +3515,7 @@ components:
                           description:
                             type: string
                             example: Main hall
+                        additionalProperties: false
                       borough:
                         type: string
                         description: >-
@@ -3410,6 +3548,10 @@ components:
                             type: string
                             enum:
                               - WGS84 (Decimal Degrees)
+                        required:
+                          - latitude
+                          - longitude
+                        additionalProperties: false
                       contact:
                         type: object
                         description: >-
@@ -3428,6 +3570,13 @@ components:
                             type: string
                             description: Phone number of the contact person.
                             example: +49 30 12345678
+                        additionalProperties: false
+                    required:
+                      - type
+                      - identifier
+                      - metadata
+                      - title
+                    additionalProperties: false
                 organizationsReferences:
                   type: array
                   items:
@@ -3447,8 +3596,13 @@ components:
                         example:
                           de: Konzert
                           en: concert
+                    required:
+                      - referenceType
+                      - referenceId
+                    additionalProperties: false
       required:
         - success
+      additionalProperties: false
     UpdateOrganizationRequest:
       type: object
       properties:
@@ -3502,6 +3656,7 @@ components:
             description:
               type: string
               example: Main hall
+          additionalProperties: false
         borough:
           type: string
           description: >-
@@ -3534,6 +3689,10 @@ components:
               type: string
               enum:
                 - WGS84 (Decimal Degrees)
+          required:
+            - latitude
+            - longitude
+          additionalProperties: false
         contact:
           type: object
           description: >-
@@ -3552,6 +3711,8 @@ components:
               type: string
               description: Phone number of the contact person.
               example: +49 30 12345678
+          additionalProperties: false
+      additionalProperties: false
     GetAttractionsResponse:
       type: object
       properties:
@@ -3586,11 +3747,6 @@ components:
                   type: array
                   items:
                     type: object
-                    required:
-                      - type
-                      - identifier
-                      - metadata
-                      - title
                     properties:
                       type:
                         type: string
@@ -3600,9 +3756,6 @@ components:
                         type: string
                       metadata:
                         type: object
-                        required:
-                          - created
-                          - updated
                         properties:
                           created:
                             type: string
@@ -3634,6 +3787,10 @@ components:
                               - en
                             items:
                               type: string
+                        required:
+                          - created
+                          - updated
+                        additionalProperties: false
                       status:
                         type: string
                         enum:
@@ -3698,6 +3855,13 @@ components:
                               example: https://example.com/
                           required:
                             - url
+                          additionalProperties: false
+                    required:
+                      - type
+                      - identifier
+                      - metadata
+                      - title
+                    additionalProperties: false
                 attractionsReferences:
                   type: array
                   items:
@@ -3717,8 +3881,13 @@ components:
                         example:
                           de: Konzert
                           en: concert
+                    required:
+                      - referenceType
+                      - referenceId
+                    additionalProperties: false
       required:
         - success
+      additionalProperties: false
     CreateAttractionRequest:
       type: object
       properties:
@@ -3780,6 +3949,7 @@ components:
                 example: https://example.com/
             required:
               - url
+            additionalProperties: false
         metadata:
           type: object
           properties:
@@ -3787,8 +3957,10 @@ components:
               type: string
             originObjectID:
               type: string
+          additionalProperties: false
       required:
         - title
+      additionalProperties: false
     CreateAttractionResponse:
       type: object
       properties:
@@ -3818,14 +3990,21 @@ components:
                   example:
                     de: Konzert
                     en: concert
+              required:
+                - referenceType
+                - referenceId
+              additionalProperties: false
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     SearchAttractionsRequest:
       type: object
       properties:
         searchFilter:
           type: object
           additionalProperties: true
+      additionalProperties: false
     SearchAttractionsResponse:
       type: object
       properties:
@@ -3860,11 +4039,6 @@ components:
                   type: array
                   items:
                     type: object
-                    required:
-                      - type
-                      - identifier
-                      - metadata
-                      - title
                     properties:
                       type:
                         type: string
@@ -3874,9 +4048,6 @@ components:
                         type: string
                       metadata:
                         type: object
-                        required:
-                          - created
-                          - updated
                         properties:
                           created:
                             type: string
@@ -3908,6 +4079,10 @@ components:
                               - en
                             items:
                               type: string
+                        required:
+                          - created
+                          - updated
+                        additionalProperties: false
                       status:
                         type: string
                         enum:
@@ -3972,6 +4147,13 @@ components:
                               example: https://example.com/
                           required:
                             - url
+                          additionalProperties: false
+                    required:
+                      - type
+                      - identifier
+                      - metadata
+                      - title
+                    additionalProperties: false
                 attractionsReferences:
                   type: array
                   items:
@@ -3991,8 +4173,13 @@ components:
                         example:
                           de: Konzert
                           en: concert
+                    required:
+                      - referenceType
+                      - referenceId
+                    additionalProperties: false
       required:
         - success
+      additionalProperties: false
     GetAttractionResponse:
       type: object
       properties:
@@ -4005,11 +4192,6 @@ components:
           properties:
             attraction:
               type: object
-              required:
-                - type
-                - identifier
-                - metadata
-                - title
               properties:
                 type:
                   type: string
@@ -4019,9 +4201,6 @@ components:
                   type: string
                 metadata:
                   type: object
-                  required:
-                    - created
-                    - updated
                   properties:
                     created:
                       type: string
@@ -4051,6 +4230,10 @@ components:
                         - en
                       items:
                         type: string
+                  required:
+                    - created
+                    - updated
+                  additionalProperties: false
                 status:
                   type: string
                   enum:
@@ -4115,6 +4298,13 @@ components:
                         example: https://example.com/
                     required:
                       - url
+                    additionalProperties: false
+              required:
+                - type
+                - identifier
+                - metadata
+                - title
+              additionalProperties: false
             attractionReference:
               type: object
               properties:
@@ -4132,8 +4322,14 @@ components:
                   example:
                     de: Konzert
                     en: concert
+              required:
+                - referenceType
+                - referenceId
+              additionalProperties: false
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     UpdateAttractionRequest:
       type: object
       properties:
@@ -4195,6 +4391,8 @@ components:
                 example: https://example.com/
             required:
               - url
+            additionalProperties: false
+      additionalProperties: false
     GetLocationsResponse:
       type: object
       properties:
@@ -4229,9 +4427,6 @@ components:
                   type: array
                   items:
                     type: object
-                    required:
-                      - type
-                      - identifier
                     properties:
                       type:
                         type: string
@@ -4241,9 +4436,6 @@ components:
                         type: string
                       metadata:
                         type: object
-                        required:
-                          - created
-                          - updated
                         properties:
                           created:
                             type: string
@@ -4275,6 +4467,10 @@ components:
                               - en
                             items:
                               type: string
+                        required:
+                          - created
+                          - updated
+                        additionalProperties: false
                       status:
                         type: string
                         enum:
@@ -4320,6 +4516,7 @@ components:
                           description:
                             type: string
                             example: Main hall
+                        additionalProperties: false
                       borough:
                         type: string
                         description: >-
@@ -4352,6 +4549,10 @@ components:
                             type: string
                             enum:
                               - WGS84 (Decimal Degrees)
+                        required:
+                          - latitude
+                          - longitude
+                        additionalProperties: false
                       openingStatus:
                         type: string
                         enum:
@@ -4363,12 +4564,6 @@ components:
                         items:
                           type: object
                           properties:
-                            closes:
-                              type: string
-                              description: >-
-                                The closing hour of the place or service on the
-                                given day(s) of the week.
-                              example: "22:00"
                             dayOfWeek:
                               type: string
                               enum:
@@ -4386,8 +4581,14 @@ components:
                               type: string
                               description: >-
                                 The opening hour of the place or service on the
-                                given day(s) of the week.
+                                given day of the week.
                               example: "12:00"
+                            closes:
+                              type: string
+                              description: >-
+                                The closing hour of the place or service on the
+                                given day of the week.
+                              example: "22:00"
                             validFrom:
                               type: string
                               description: The date when the item becomes valid.
@@ -4397,6 +4598,11 @@ components:
                                 The date after when the item is not valid. For
                                 example the end of an offer, salary period, or a
                                 period of opening hours.
+                          required:
+                            - dayOfWeek
+                            - opens
+                            - closes
+                          additionalProperties: false
                       inLanguages:
                         type: array
                         description: List of languages this object is available in.
@@ -4429,6 +4635,7 @@ components:
                                 example: https://example.com/
                             required:
                               - url
+                            additionalProperties: false
                       manager:
                         type: object
                         properties:
@@ -4447,6 +4654,10 @@ components:
                             example:
                               de: Konzert
                               en: concert
+                        required:
+                          - referenceType
+                          - referenceId
+                        additionalProperties: false
                         description: The managing person of this location.
                       contact:
                         type: object
@@ -4464,6 +4675,13 @@ components:
                             type: string
                             description: Phone number of the contact person.
                             example: +49 30 12345678
+                        additionalProperties: false
+                    required:
+                      - type
+                      - identifier
+                      - metadata
+                      - title
+                    additionalProperties: false
                 locationsReferences:
                   type: array
                   items:
@@ -4483,8 +4701,13 @@ components:
                         example:
                           de: Konzert
                           en: concert
+                    required:
+                      - referenceType
+                      - referenceId
+                    additionalProperties: false
       required:
         - success
+      additionalProperties: false
     CreateLocationRequest:
       type: object
       properties:
@@ -4526,6 +4749,7 @@ components:
             description:
               type: string
               example: Main hall
+          additionalProperties: false
         borough:
           type: string
           description: >-
@@ -4558,17 +4782,15 @@ components:
               type: string
               enum:
                 - WGS84 (Decimal Degrees)
+          required:
+            - latitude
+            - longitude
+          additionalProperties: false
         openingHours:
           type: array
           items:
             type: object
             properties:
-              closes:
-                type: string
-                description: >-
-                  The closing hour of the place or service on the given day(s)
-                  of the week.
-                example: "22:00"
               dayOfWeek:
                 type: string
                 enum:
@@ -4583,9 +4805,15 @@ components:
               opens:
                 type: string
                 description: >-
-                  The opening hour of the place or service on the given day(s)
-                  of the week.
+                  The opening hour of the place or service on the given day of
+                  the week.
                 example: "12:00"
+              closes:
+                type: string
+                description: >-
+                  The closing hour of the place or service on the given day of
+                  the week.
+                example: "22:00"
               validFrom:
                 type: string
                 description: The date when the item becomes valid.
@@ -4594,6 +4822,11 @@ components:
                 description: >-
                   The date after when the item is not valid. For example the end
                   of an offer, salary period, or a period of opening hours.
+            required:
+              - dayOfWeek
+              - opens
+              - closes
+            additionalProperties: false
         inLanguages:
           type: array
           description: List of languages this object is available in.
@@ -4622,6 +4855,7 @@ components:
                   example: https://example.com/
               required:
                 - url
+              additionalProperties: false
         manager:
           type: object
           properties:
@@ -4639,6 +4873,10 @@ components:
               example:
                 de: Konzert
                 en: concert
+          required:
+            - referenceType
+            - referenceId
+          additionalProperties: false
         contact:
           type: object
           description: >-
@@ -4657,6 +4895,7 @@ components:
               type: string
               description: Phone number of the contact person.
               example: +49 30 12345678
+          additionalProperties: false
         metadata:
           type: object
           properties:
@@ -4664,8 +4903,10 @@ components:
               type: string
             originObjectID:
               type: string
+          additionalProperties: false
       required:
         - title
+      additionalProperties: false
     CreateLocationResponse:
       type: object
       properties:
@@ -4695,14 +4936,21 @@ components:
                   example:
                     de: Konzert
                     en: concert
+              required:
+                - referenceType
+                - referenceId
+              additionalProperties: false
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     SearchLocationsRequest:
       type: object
       properties:
         searchFilter:
           type: object
           additionalProperties: true
+      additionalProperties: false
     SearchLocationsResponse:
       type: object
       properties:
@@ -4737,9 +4985,6 @@ components:
                   type: array
                   items:
                     type: object
-                    required:
-                      - type
-                      - identifier
                     properties:
                       type:
                         type: string
@@ -4749,9 +4994,6 @@ components:
                         type: string
                       metadata:
                         type: object
-                        required:
-                          - created
-                          - updated
                         properties:
                           created:
                             type: string
@@ -4783,6 +5025,10 @@ components:
                               - en
                             items:
                               type: string
+                        required:
+                          - created
+                          - updated
+                        additionalProperties: false
                       status:
                         type: string
                         enum:
@@ -4828,6 +5074,7 @@ components:
                           description:
                             type: string
                             example: Main hall
+                        additionalProperties: false
                       borough:
                         type: string
                         description: >-
@@ -4860,6 +5107,10 @@ components:
                             type: string
                             enum:
                               - WGS84 (Decimal Degrees)
+                        required:
+                          - latitude
+                          - longitude
+                        additionalProperties: false
                       openingStatus:
                         type: string
                         enum:
@@ -4871,12 +5122,6 @@ components:
                         items:
                           type: object
                           properties:
-                            closes:
-                              type: string
-                              description: >-
-                                The closing hour of the place or service on the
-                                given day(s) of the week.
-                              example: "22:00"
                             dayOfWeek:
                               type: string
                               enum:
@@ -4894,8 +5139,14 @@ components:
                               type: string
                               description: >-
                                 The opening hour of the place or service on the
-                                given day(s) of the week.
+                                given day of the week.
                               example: "12:00"
+                            closes:
+                              type: string
+                              description: >-
+                                The closing hour of the place or service on the
+                                given day of the week.
+                              example: "22:00"
                             validFrom:
                               type: string
                               description: The date when the item becomes valid.
@@ -4905,6 +5156,11 @@ components:
                                 The date after when the item is not valid. For
                                 example the end of an offer, salary period, or a
                                 period of opening hours.
+                          required:
+                            - dayOfWeek
+                            - opens
+                            - closes
+                          additionalProperties: false
                       inLanguages:
                         type: array
                         description: List of languages this object is available in.
@@ -4937,6 +5193,7 @@ components:
                                 example: https://example.com/
                             required:
                               - url
+                            additionalProperties: false
                       manager:
                         type: object
                         properties:
@@ -4955,6 +5212,10 @@ components:
                             example:
                               de: Konzert
                               en: concert
+                        required:
+                          - referenceType
+                          - referenceId
+                        additionalProperties: false
                         description: The managing person of this location.
                       contact:
                         type: object
@@ -4972,6 +5233,13 @@ components:
                             type: string
                             description: Phone number of the contact person.
                             example: +49 30 12345678
+                        additionalProperties: false
+                    required:
+                      - type
+                      - identifier
+                      - metadata
+                      - title
+                    additionalProperties: false
                 locationsReferences:
                   type: array
                   items:
@@ -4991,8 +5259,13 @@ components:
                         example:
                           de: Konzert
                           en: concert
+                    required:
+                      - referenceType
+                      - referenceId
+                    additionalProperties: false
       required:
         - success
+      additionalProperties: false
     GetLocationResponse:
       type: object
       properties:
@@ -5005,9 +5278,6 @@ components:
           properties:
             location:
               type: object
-              required:
-                - type
-                - identifier
               properties:
                 type:
                   type: string
@@ -5017,9 +5287,6 @@ components:
                   type: string
                 metadata:
                   type: object
-                  required:
-                    - created
-                    - updated
                   properties:
                     created:
                       type: string
@@ -5049,6 +5316,10 @@ components:
                         - en
                       items:
                         type: string
+                  required:
+                    - created
+                    - updated
+                  additionalProperties: false
                 status:
                   type: string
                   enum:
@@ -5094,6 +5365,7 @@ components:
                     description:
                       type: string
                       example: Main hall
+                  additionalProperties: false
                 borough:
                   type: string
                   description: >-
@@ -5126,6 +5398,10 @@ components:
                       type: string
                       enum:
                         - WGS84 (Decimal Degrees)
+                  required:
+                    - latitude
+                    - longitude
+                  additionalProperties: false
                 openingStatus:
                   type: string
                   enum:
@@ -5137,12 +5413,6 @@ components:
                   items:
                     type: object
                     properties:
-                      closes:
-                        type: string
-                        description: >-
-                          The closing hour of the place or service on the given
-                          day(s) of the week.
-                        example: "22:00"
                       dayOfWeek:
                         type: string
                         enum:
@@ -5160,8 +5430,14 @@ components:
                         type: string
                         description: >-
                           The opening hour of the place or service on the given
-                          day(s) of the week.
+                          day of the week.
                         example: "12:00"
+                      closes:
+                        type: string
+                        description: >-
+                          The closing hour of the place or service on the given
+                          day of the week.
+                        example: "22:00"
                       validFrom:
                         type: string
                         description: The date when the item becomes valid.
@@ -5171,6 +5447,11 @@ components:
                           The date after when the item is not valid. For example
                           the end of an offer, salary period, or a period of
                           opening hours.
+                    required:
+                      - dayOfWeek
+                      - opens
+                      - closes
+                    additionalProperties: false
                 inLanguages:
                   type: array
                   description: List of languages this object is available in.
@@ -5203,6 +5484,7 @@ components:
                           example: https://example.com/
                       required:
                         - url
+                      additionalProperties: false
                 manager:
                   type: object
                   properties:
@@ -5220,6 +5502,10 @@ components:
                       example:
                         de: Konzert
                         en: concert
+                  required:
+                    - referenceType
+                    - referenceId
+                  additionalProperties: false
                   description: The managing person of this location.
                 contact:
                   type: object
@@ -5237,6 +5523,13 @@ components:
                       type: string
                       description: Phone number of the contact person.
                       example: +49 30 12345678
+                  additionalProperties: false
+              required:
+                - type
+                - identifier
+                - metadata
+                - title
+              additionalProperties: false
             locationReference:
               type: object
               properties:
@@ -5254,8 +5547,14 @@ components:
                   example:
                     de: Konzert
                     en: concert
+              required:
+                - referenceType
+                - referenceId
+              additionalProperties: false
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     UpdateLocationRequest:
       type: object
       properties:
@@ -5297,6 +5596,7 @@ components:
             description:
               type: string
               example: Main hall
+          additionalProperties: false
         borough:
           type: string
           description: >-
@@ -5329,6 +5629,10 @@ components:
               type: string
               enum:
                 - WGS84 (Decimal Degrees)
+          required:
+            - latitude
+            - longitude
+          additionalProperties: false
         inLanguages:
           type: array
           description: List of languages this object is available in.
@@ -5357,6 +5661,7 @@ components:
                   example: https://example.com/
               required:
                 - url
+              additionalProperties: false
         contact:
           type: object
           description: >-
@@ -5375,6 +5680,8 @@ components:
               type: string
               description: Phone number of the contact person.
               example: +49 30 12345678
+          additionalProperties: false
+      additionalProperties: false
     SetLocationManagerRequest:
       type: object
       properties:
@@ -5392,6 +5699,7 @@ components:
             en: concert
       required:
         - organizationIdentifier
+      additionalProperties: false
     ClaimLocationRequest:
       type: object
       properties:
@@ -5414,10 +5722,12 @@ components:
             phone:
               type: string
               description: Contact person's phone number (optional).
+          additionalProperties: false
       required:
         - organizationIdentifier
         - justification
         - contact
+      additionalProperties: false
     GetEventsResponse:
       type: object
       properties:
@@ -5452,9 +5762,6 @@ components:
                   type: array
                   items:
                     type: object
-                    required:
-                      - type
-                      - identifier
                     properties:
                       type:
                         type: string
@@ -5464,9 +5771,6 @@ components:
                         type: string
                       metadata:
                         type: object
-                        required:
-                          - created
-                          - updated
                         properties:
                           created:
                             type: string
@@ -5498,6 +5802,10 @@ components:
                               - en
                             items:
                               type: string
+                        required:
+                          - created
+                          - updated
+                        additionalProperties: false
                       status:
                         type: string
                         enum:
@@ -5548,6 +5856,7 @@ components:
                             type: string
                             description: The time the event end, in timezone Europe/Berlin.
                             example: "22:00"
+                        additionalProperties: false
                       title:
                         type: object
                         additionalProperties:
@@ -5613,6 +5922,10 @@ components:
                               example:
                                 de: Konzert
                                 en: concert
+                          required:
+                            - referenceType
+                            - referenceId
+                          additionalProperties: false
                       attractions:
                         type: array
                         items:
@@ -5633,6 +5946,10 @@ components:
                               example:
                                 de: Konzert
                                 en: concert
+                          required:
+                            - referenceType
+                            - referenceId
+                          additionalProperties: false
                       organizer:
                         type: object
                         properties:
@@ -5651,6 +5968,10 @@ components:
                             example:
                               de: Konzert
                               en: concert
+                        required:
+                          - referenceType
+                          - referenceId
+                        additionalProperties: false
                       contact:
                         type: object
                         description: >-
@@ -5669,6 +5990,7 @@ components:
                             type: string
                             description: Phone number of the contact person.
                             example: +49 30 12345678
+                        additionalProperties: false
                       admission:
                         type: object
                         description: >-
@@ -5700,6 +6022,12 @@ components:
                           admissionLink:
                             type: string
                             example: https://example.com/
+                        additionalProperties: false
+                    required:
+                      - type
+                      - identifier
+                      - metadata
+                    additionalProperties: false
                 eventsReferences:
                   type: array
                   items:
@@ -5719,8 +6047,13 @@ components:
                         example:
                           de: Konzert
                           en: concert
+                    required:
+                      - referenceType
+                      - referenceId
+                    additionalProperties: false
       required:
         - success
+      additionalProperties: false
     CreateEventRequest:
       type: object
       properties:
@@ -5759,6 +6092,7 @@ components:
               type: string
               description: The time the event end, in timezone Europe/Berlin.
               example: "22:00"
+          additionalProperties: false
         title:
           type: object
           additionalProperties:
@@ -5822,6 +6156,10 @@ components:
                 example:
                   de: Konzert
                   en: concert
+            required:
+              - referenceType
+              - referenceId
+            additionalProperties: false
         attractions:
           type: array
           items:
@@ -5841,6 +6179,10 @@ components:
                 example:
                   de: Konzert
                   en: concert
+            required:
+              - referenceType
+              - referenceId
+            additionalProperties: false
         organizer:
           type: object
           properties:
@@ -5858,6 +6200,10 @@ components:
               example:
                 de: Konzert
                 en: concert
+          required:
+            - referenceType
+            - referenceId
+          additionalProperties: false
         contact:
           type: object
           description: >-
@@ -5876,6 +6222,7 @@ components:
               type: string
               description: Phone number of the contact person.
               example: +49 30 12345678
+          additionalProperties: false
         admission:
           type: object
           description: Information about the admission to the event/attraction.
@@ -5904,6 +6251,7 @@ components:
             admissionLink:
               type: string
               example: https://example.com/
+          additionalProperties: false
         metadata:
           type: object
           properties:
@@ -5911,6 +6259,13 @@ components:
               type: string
             originObjectID:
               type: string
+          additionalProperties: false
+      required:
+        - schedule
+        - locations
+        - attractions
+        - organizer
+      additionalProperties: false
     CreateEventResponse:
       type: object
       properties:
@@ -5940,8 +6295,14 @@ components:
                   example:
                     de: Konzert
                     en: concert
+              required:
+                - referenceType
+                - referenceId
+              additionalProperties: false
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     SearchEventsRequest:
       type: object
       properties:
@@ -5965,6 +6326,7 @@ components:
               enum:
                 - any
                 - all
+          additionalProperties: false
         byLocationAccessibilityTags:
           type: object
           properties:
@@ -5977,8 +6339,10 @@ components:
               enum:
                 - any
                 - all
+          additionalProperties: false
         inTheFuture:
           type: boolean
+      additionalProperties: false
     SearchEventsResponse:
       type: object
       properties:
@@ -6013,9 +6377,6 @@ components:
                   type: array
                   items:
                     type: object
-                    required:
-                      - type
-                      - identifier
                     properties:
                       type:
                         type: string
@@ -6025,9 +6386,6 @@ components:
                         type: string
                       metadata:
                         type: object
-                        required:
-                          - created
-                          - updated
                         properties:
                           created:
                             type: string
@@ -6059,6 +6417,10 @@ components:
                               - en
                             items:
                               type: string
+                        required:
+                          - created
+                          - updated
+                        additionalProperties: false
                       status:
                         type: string
                         enum:
@@ -6109,6 +6471,7 @@ components:
                             type: string
                             description: The time the event end, in timezone Europe/Berlin.
                             example: "22:00"
+                        additionalProperties: false
                       title:
                         type: object
                         additionalProperties:
@@ -6174,6 +6537,10 @@ components:
                               example:
                                 de: Konzert
                                 en: concert
+                          required:
+                            - referenceType
+                            - referenceId
+                          additionalProperties: false
                       attractions:
                         type: array
                         items:
@@ -6194,6 +6561,10 @@ components:
                               example:
                                 de: Konzert
                                 en: concert
+                          required:
+                            - referenceType
+                            - referenceId
+                          additionalProperties: false
                       organizer:
                         type: object
                         properties:
@@ -6212,6 +6583,10 @@ components:
                             example:
                               de: Konzert
                               en: concert
+                        required:
+                          - referenceType
+                          - referenceId
+                        additionalProperties: false
                       contact:
                         type: object
                         description: >-
@@ -6230,6 +6605,7 @@ components:
                             type: string
                             description: Phone number of the contact person.
                             example: +49 30 12345678
+                        additionalProperties: false
                       admission:
                         type: object
                         description: >-
@@ -6261,6 +6637,12 @@ components:
                           admissionLink:
                             type: string
                             example: https://example.com/
+                        additionalProperties: false
+                    required:
+                      - type
+                      - identifier
+                      - metadata
+                    additionalProperties: false
                 eventsReferences:
                   type: array
                   items:
@@ -6280,8 +6662,13 @@ components:
                         example:
                           de: Konzert
                           en: concert
+                    required:
+                      - referenceType
+                      - referenceId
+                    additionalProperties: false
       required:
         - success
+      additionalProperties: false
     GetEventResponse:
       type: object
       properties:
@@ -6294,9 +6681,6 @@ components:
           properties:
             event:
               type: object
-              required:
-                - type
-                - identifier
               properties:
                 type:
                   type: string
@@ -6306,9 +6690,6 @@ components:
                   type: string
                 metadata:
                   type: object
-                  required:
-                    - created
-                    - updated
                   properties:
                     created:
                       type: string
@@ -6338,6 +6719,10 @@ components:
                         - en
                       items:
                         type: string
+                  required:
+                    - created
+                    - updated
+                  additionalProperties: false
                 status:
                   type: string
                   enum:
@@ -6386,6 +6771,7 @@ components:
                       type: string
                       description: The time the event end, in timezone Europe/Berlin.
                       example: "22:00"
+                  additionalProperties: false
                 title:
                   type: object
                   additionalProperties:
@@ -6450,6 +6836,10 @@ components:
                         example:
                           de: Konzert
                           en: concert
+                    required:
+                      - referenceType
+                      - referenceId
+                    additionalProperties: false
                 attractions:
                   type: array
                   items:
@@ -6469,6 +6859,10 @@ components:
                         example:
                           de: Konzert
                           en: concert
+                    required:
+                      - referenceType
+                      - referenceId
+                    additionalProperties: false
                 organizer:
                   type: object
                   properties:
@@ -6486,6 +6880,10 @@ components:
                       example:
                         de: Konzert
                         en: concert
+                  required:
+                    - referenceType
+                    - referenceId
+                  additionalProperties: false
                 contact:
                   type: object
                   description: >-
@@ -6504,6 +6902,7 @@ components:
                       type: string
                       description: Phone number of the contact person.
                       example: +49 30 12345678
+                  additionalProperties: false
                 admission:
                   type: object
                   description: Information about the admission to the event/attraction.
@@ -6532,6 +6931,12 @@ components:
                     admissionLink:
                       type: string
                       example: https://example.com/
+                  additionalProperties: false
+              required:
+                - type
+                - identifier
+                - metadata
+              additionalProperties: false
             eventReference:
               type: object
               properties:
@@ -6549,8 +6954,14 @@ components:
                   example:
                     de: Konzert
                     en: concert
+              required:
+                - referenceType
+                - referenceId
+              additionalProperties: false
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     UpdateEventRequest:
       type: object
       properties:
@@ -6616,6 +7027,7 @@ components:
               type: string
               description: Phone number of the contact person.
               example: +49 30 12345678
+          additionalProperties: false
         admission:
           type: object
           description: Information about the admission to the event/attraction.
@@ -6644,6 +7056,8 @@ components:
             admissionLink:
               type: string
               example: https://example.com/
+          additionalProperties: false
+      additionalProperties: false
     AddEventLocationRequest:
       type: object
       properties:
@@ -6659,6 +7073,9 @@ components:
           example:
             de: Konzert
             en: concert
+      required:
+        - locationIdentifier
+      additionalProperties: false
     RemoveEventLocationRequest:
       type: object
       properties:
@@ -6666,6 +7083,7 @@ components:
           type: string
       required:
         - locationIdentifier
+      additionalProperties: false
     AddEventAttractionRequest:
       type: object
       properties:
@@ -6681,6 +7099,9 @@ components:
           example:
             de: Konzert
             en: concert
+      required:
+        - attractionIdentifier
+      additionalProperties: false
     RemoveEventAttractionRequest:
       type: object
       properties:
@@ -6688,6 +7109,7 @@ components:
           type: string
       required:
         - attractionIdentifier
+      additionalProperties: false
     SetEventOrganizerRequest:
       type: object
       properties:
@@ -6703,6 +7125,9 @@ components:
           example:
             de: Konzert
             en: concert
+      required:
+        - organizationIdentifier
+      additionalProperties: false
     RescheduleEventRequest:
       type: object
       properties:
@@ -6720,6 +7145,7 @@ components:
           type: string
         setToRescheduled:
           type: boolean
+      additionalProperties: false
     DuplicateEventResponse:
       properties:
         success:
@@ -6733,15 +7159,21 @@ components:
           properties:
             eventIdentifier:
               type: string
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     LoginRequest:
       type: object
       properties:
-        password:
-          type: string
         email:
           type: string
+        password:
+          type: string
+      required:
+        - email
+        - password
+      additionalProperties: false
     LoginResponse:
       type: object
       properties:
@@ -6751,10 +7183,6 @@ components:
           type: string
         data:
           type: object
-          required:
-            - accessToken
-            - expiresIn
-            - user
           properties:
             accessToken:
               type: string
@@ -6784,11 +7212,21 @@ components:
                 permissionFlags:
                   type: number
               required:
+                - type
                 - identifier
                 - email
+                - createdAt
+                - updatedAt
                 - permissionFlags
+              additionalProperties: false
+          required:
+            - accessToken
+            - expiresIn
+            - user
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     GetUsersResponse:
       type: object
       properties:
@@ -6845,11 +7283,16 @@ components:
                       permissionFlags:
                         type: number
                     required:
+                      - type
                       - identifier
                       - email
+                      - createdAt
+                      - updatedAt
                       - permissionFlags
+                    additionalProperties: false
       required:
         - success
+      additionalProperties: false
     CreateUserRequest:
       type: object
       properties:
@@ -6864,6 +7307,7 @@ components:
       required:
         - password
         - email
+      additionalProperties: false
     EmailAlreadyInUseError:
       type: object
       properties:
@@ -6884,9 +7328,11 @@ components:
               type: string
           required:
             - code
+          additionalProperties: false
       required:
         - success
         - error
+      additionalProperties: false
     GetUserResponse:
       type: object
       properties:
@@ -6921,11 +7367,17 @@ components:
                 permissionFlags:
                   type: number
               required:
+                - type
                 - identifier
                 - email
+                - createdAt
+                - updatedAt
                 - permissionFlags
+              additionalProperties: false
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     UpdateUserRequest:
       type: object
       properties:
@@ -6935,6 +7387,7 @@ components:
           type: string
         lastName:
           type: string
+      additionalProperties: false
     RemoveExternalLinkRequest:
       type: object
       properties:
@@ -6942,6 +7395,7 @@ components:
           type: string
       required:
         - url
+      additionalProperties: false
     CreateUserResponse:
       properties:
         success:
@@ -6955,8 +7409,10 @@ components:
           properties:
             userIdentifier:
               type: string
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     GetTagsResponse:
       type: object
       properties:
@@ -6991,9 +7447,6 @@ components:
                   metadata:
                     allOf:
                       - type: object
-                        required:
-                          - created
-                          - updated
                         properties:
                           created:
                             type: string
@@ -7025,6 +7478,10 @@ components:
                               - en
                             items:
                               type: string
+                        required:
+                          - created
+                          - updated
+                        additionalProperties: false
                       - type: object
                         properties:
                           externalIDs:
@@ -7032,10 +7489,15 @@ components:
                             additionalProperties:
                               type: string
                 required:
+                  - type
                   - identifier
                   - title
+                  - metadata
+                additionalProperties: false
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     GetTagResponse:
       type: object
       properties:
@@ -7068,9 +7530,6 @@ components:
                 metadata:
                   allOf:
                     - type: object
-                      required:
-                        - created
-                        - updated
                       properties:
                         created:
                           type: string
@@ -7102,6 +7561,10 @@ components:
                             - en
                           items:
                             type: string
+                      required:
+                        - created
+                        - updated
+                      additionalProperties: false
                     - type: object
                       properties:
                         externalIDs:
@@ -7109,10 +7572,15 @@ components:
                           additionalProperties:
                             type: string
               required:
+                - type
                 - identifier
                 - title
+                - metadata
+              additionalProperties: false
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     CreateTagRequest:
       type: object
       properties:
@@ -7133,6 +7601,7 @@ components:
               type: object
       required:
         - title
+      additionalProperties: false
     CreateTagResponse:
       properties:
         success:
@@ -7166,9 +7635,6 @@ components:
                 metadata:
                   allOf:
                     - type: object
-                      required:
-                        - created
-                        - updated
                       properties:
                         created:
                           type: string
@@ -7200,6 +7666,10 @@ components:
                             - en
                           items:
                             type: string
+                      required:
+                        - created
+                        - updated
+                      additionalProperties: false
                     - type: object
                       properties:
                         externalIDs:
@@ -7207,10 +7677,15 @@ components:
                           additionalProperties:
                             type: string
               required:
+                - type
                 - identifier
                 - title
+                - metadata
+              additionalProperties: false
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     GetAdminAttractionResponse:
       type: object
       properties:
@@ -7223,12 +7698,6 @@ components:
           properties:
             attraction:
               type: object
-              required:
-                - type
-                - identifier
-                - metadata
-                - title
-                - events
               properties:
                 type:
                   type: string
@@ -7238,9 +7707,6 @@ components:
                   type: string
                 metadata:
                   type: object
-                  required:
-                    - created
-                    - updated
                   properties:
                     created:
                       type: string
@@ -7270,6 +7736,10 @@ components:
                         - en
                       items:
                         type: string
+                  required:
+                    - created
+                    - updated
+                  additionalProperties: false
                 status:
                   type: string
                   enum:
@@ -7324,9 +7794,6 @@ components:
                   type: array
                   items:
                     type: object
-                    required:
-                      - type
-                      - identifier
                     properties:
                       type:
                         type: string
@@ -7336,9 +7803,6 @@ components:
                         type: string
                       metadata:
                         type: object
-                        required:
-                          - created
-                          - updated
                         properties:
                           created:
                             type: string
@@ -7370,6 +7834,10 @@ components:
                               - en
                             items:
                               type: string
+                        required:
+                          - created
+                          - updated
+                        additionalProperties: false
                       status:
                         type: string
                         enum:
@@ -7420,6 +7888,7 @@ components:
                             type: string
                             description: The time the event end, in timezone Europe/Berlin.
                             example: "22:00"
+                        additionalProperties: false
                       title:
                         type: object
                         additionalProperties:
@@ -7485,6 +7954,10 @@ components:
                               example:
                                 de: Konzert
                                 en: concert
+                          required:
+                            - referenceType
+                            - referenceId
+                          additionalProperties: false
                       attractions:
                         type: array
                         items:
@@ -7505,6 +7978,10 @@ components:
                               example:
                                 de: Konzert
                                 en: concert
+                          required:
+                            - referenceType
+                            - referenceId
+                          additionalProperties: false
                       organizer:
                         type: object
                         properties:
@@ -7523,6 +8000,10 @@ components:
                             example:
                               de: Konzert
                               en: concert
+                        required:
+                          - referenceType
+                          - referenceId
+                        additionalProperties: false
                       contact:
                         type: object
                         description: >-
@@ -7541,6 +8022,7 @@ components:
                             type: string
                             description: Phone number of the contact person.
                             example: +49 30 12345678
+                        additionalProperties: false
                       admission:
                         type: object
                         description: >-
@@ -7572,6 +8054,12 @@ components:
                           admissionLink:
                             type: string
                             example: https://example.com/
+                        additionalProperties: false
+                    required:
+                      - type
+                      - identifier
+                      - metadata
+                    additionalProperties: false
                 externalLinks:
                   type: array
                   description: Links to external resources related to this object.
@@ -7586,8 +8074,18 @@ components:
                         example: https://example.com/
                     required:
                       - url
+                    additionalProperties: false
+              required:
+                - type
+                - identifier
+                - metadata
+                - title
+                - events
+              additionalProperties: false
+          additionalProperties: false
       required:
         - success
+      additionalProperties: false
     GetAdminAttractionsResponse:
       type: object
       properties:
@@ -7624,12 +8122,6 @@ components:
                   type: array
                   items:
                     type: object
-                    required:
-                      - type
-                      - identifier
-                      - metadata
-                      - title
-                      - events
                     properties:
                       type:
                         type: string
@@ -7639,9 +8131,6 @@ components:
                         type: string
                       metadata:
                         type: object
-                        required:
-                          - created
-                          - updated
                         properties:
                           created:
                             type: string
@@ -7673,6 +8162,10 @@ components:
                               - en
                             items:
                               type: string
+                        required:
+                          - created
+                          - updated
+                        additionalProperties: false
                       status:
                         type: string
                         enum:
@@ -7727,9 +8220,6 @@ components:
                         type: array
                         items:
                           type: object
-                          required:
-                            - type
-                            - identifier
                           properties:
                             type:
                               type: string
@@ -7739,9 +8229,6 @@ components:
                               type: string
                             metadata:
                               type: object
-                              required:
-                                - created
-                                - updated
                               properties:
                                 created:
                                   type: string
@@ -7775,6 +8262,10 @@ components:
                                     - en
                                   items:
                                     type: string
+                              required:
+                                - created
+                                - updated
+                              additionalProperties: false
                             status:
                               type: string
                               enum:
@@ -7827,6 +8318,7 @@ components:
                                     The time the event end, in timezone
                                     Europe/Berlin.
                                   example: "22:00"
+                              additionalProperties: false
                             title:
                               type: object
                               additionalProperties:
@@ -7895,6 +8387,10 @@ components:
                                     example:
                                       de: Konzert
                                       en: concert
+                                required:
+                                  - referenceType
+                                  - referenceId
+                                additionalProperties: false
                             attractions:
                               type: array
                               items:
@@ -7915,6 +8411,10 @@ components:
                                     example:
                                       de: Konzert
                                       en: concert
+                                required:
+                                  - referenceType
+                                  - referenceId
+                                additionalProperties: false
                             organizer:
                               type: object
                               properties:
@@ -7933,6 +8433,10 @@ components:
                                   example:
                                     de: Konzert
                                     en: concert
+                              required:
+                                - referenceType
+                                - referenceId
+                              additionalProperties: false
                             contact:
                               type: object
                               description: >-
@@ -7951,6 +8455,7 @@ components:
                                   type: string
                                   description: Phone number of the contact person.
                                   example: +49 30 12345678
+                              additionalProperties: false
                             admission:
                               type: object
                               description: >-
@@ -7982,6 +8487,12 @@ components:
                                 admissionLink:
                                   type: string
                                   example: https://example.com/
+                              additionalProperties: false
+                          required:
+                            - type
+                            - identifier
+                            - metadata
+                          additionalProperties: false
                       externalLinks:
                         type: array
                         description: Links to external resources related to this object.
@@ -7996,9 +8507,17 @@ components:
                               example: https://example.com/
                           required:
                             - url
+                          additionalProperties: false
+                    required:
+                      - type
+                      - identifier
+                      - metadata
+                      - title
+                      - events
+                    additionalProperties: false
       required:
         - success
-        - data
+      additionalProperties: false
     TranslatableField:
       type: object
       additionalProperties:

--- a/src/schemas/kulturdaten.berlin.openapi.generated.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.generated.yml
@@ -1553,6 +1553,7 @@ components:
     Event:
       type: object
       required:
+        - type
         - identifier
       properties:
         type:
@@ -1887,6 +1888,7 @@ components:
           items:
             type: object
             required:
+              - type
               - identifier
             properties:
               type:
@@ -2245,6 +2247,7 @@ components:
     Location:
       type: object
       required:
+        - type
         - identifier
       properties:
         type:
@@ -2472,6 +2475,7 @@ components:
     Organization:
       type: object
       required:
+        - type
         - identifier
       properties:
         type:
@@ -2694,6 +2698,7 @@ components:
             organization:
               type: object
               required:
+                - type
                 - identifier
               properties:
                 type:
@@ -2903,6 +2908,7 @@ components:
                   items:
                     type: object
                     required:
+                      - type
                       - identifier
                     properties:
                       type:
@@ -3084,10 +3090,6 @@ components:
     CreateOrganizationRequest:
       type: object
       properties:
-        type:
-          type: string
-          enum:
-            - type.Organization
         title:
           type: object
           additionalProperties:
@@ -3196,7 +3198,6 @@ components:
             originObjectID:
               type: string
       required:
-        - type
         - title
     CreateOrganizationResponse:
       properties:
@@ -3269,6 +3270,7 @@ components:
                   items:
                     type: object
                     required:
+                      - type
                       - identifier
                     properties:
                       type:
@@ -3720,10 +3722,6 @@ components:
     CreateAttractionRequest:
       type: object
       properties:
-        type:
-          type: string
-          enum:
-            - type.Attraction
         title:
           type: object
           additionalProperties:
@@ -3790,7 +3788,6 @@ components:
             originObjectID:
               type: string
       required:
-        - type
         - title
     CreateAttractionResponse:
       type: object
@@ -4233,6 +4230,7 @@ components:
                   items:
                     type: object
                     required:
+                      - type
                       - identifier
                     properties:
                       type:
@@ -4490,10 +4488,6 @@ components:
     CreateLocationRequest:
       type: object
       properties:
-        type:
-          type: string
-          enum:
-            - type.Location
         title:
           type: object
           additionalProperties:
@@ -4671,7 +4665,6 @@ components:
             originObjectID:
               type: string
       required:
-        - type
         - title
     CreateLocationResponse:
       type: object
@@ -4745,6 +4738,7 @@ components:
                   items:
                     type: object
                     required:
+                      - type
                       - identifier
                     properties:
                       type:
@@ -5012,6 +5006,7 @@ components:
             location:
               type: object
               required:
+                - type
                 - identifier
               properties:
                 type:
@@ -5458,6 +5453,7 @@ components:
                   items:
                     type: object
                     required:
+                      - type
                       - identifier
                     properties:
                       type:
@@ -5728,10 +5724,6 @@ components:
     CreateEventRequest:
       type: object
       properties:
-        type:
-          type: string
-          enum:
-            - type.Event
         schedule:
           type: object
           properties:
@@ -5919,8 +5911,6 @@ components:
               type: string
             originObjectID:
               type: string
-      required:
-        - type
     CreateEventResponse:
       type: object
       properties:
@@ -6024,6 +6014,7 @@ components:
                   items:
                     type: object
                     required:
+                      - type
                       - identifier
                     properties:
                       type:
@@ -6304,6 +6295,7 @@ components:
             event:
               type: object
               required:
+                - type
                 - identifier
               properties:
                 type:
@@ -7333,6 +7325,7 @@ components:
                   items:
                     type: object
                     required:
+                      - type
                       - identifier
                     properties:
                       type:
@@ -7735,6 +7728,7 @@ components:
                         items:
                           type: object
                           required:
+                            - type
                             - identifier
                           properties:
                             type:

--- a/src/schemas/models/AddEventAttractionRequest.yml
+++ b/src/schemas/models/AddEventAttractionRequest.yml
@@ -4,3 +4,6 @@ properties:
     type: string
   alternativeDisplayName:
     $ref: "TranslatableField.yml"
+required:
+  - attractionIdentifier
+additionalProperties: false

--- a/src/schemas/models/AddEventLocationRequest.yml
+++ b/src/schemas/models/AddEventLocationRequest.yml
@@ -4,3 +4,6 @@ properties:
     type: string
   alternativeDisplayName:
     $ref: "TranslatableField.yml"
+required:
+  - locationIdentifier
+additionalProperties: false

--- a/src/schemas/models/AddExternalLinkRequest.yml
+++ b/src/schemas/models/AddExternalLinkRequest.yml
@@ -6,3 +6,4 @@ properties:
     type: string
 required:
   - url
+additionalProperties: false

--- a/src/schemas/models/Address.yml
+++ b/src/schemas/models/Address.yml
@@ -13,3 +13,4 @@ properties:
   description:
     type: string
     example: Main hall
+additionalProperties: false

--- a/src/schemas/models/AdminAttraction.yml
+++ b/src/schemas/models/AdminAttraction.yml
@@ -1,10 +1,4 @@
 type: object
-required:
-  - type
-  - identifier
-  - metadata
-  - title
-  - events
 properties:
   type:
     type: string
@@ -40,3 +34,10 @@ properties:
       $ref: "Event.yml"
   externalLinks:
     $ref: "ExternalLinks.yml"
+required:
+  - type
+  - identifier
+  - metadata
+  - title
+  - events
+additionalProperties: false

--- a/src/schemas/models/Admission.yml
+++ b/src/schemas/models/Admission.yml
@@ -17,3 +17,4 @@ properties:
   admissionLink:
     type: string
     example: https://example.com/
+additionalProperties: false

--- a/src/schemas/models/Attraction.yml
+++ b/src/schemas/models/Attraction.yml
@@ -1,9 +1,4 @@
 type: object
-required:
-  - type
-  - identifier
-  - metadata
-  - title
 properties:
   type:
     type: string
@@ -48,3 +43,9 @@ properties:
       type: string
   externalLinks:
     $ref: "ExternalLinks.yml"
+required:
+  - type
+  - identifier
+  - metadata
+  - title
+additionalProperties: false

--- a/src/schemas/models/ClaimLocationRequest.yml
+++ b/src/schemas/models/ClaimLocationRequest.yml
@@ -19,7 +19,9 @@ properties:
       phone:
         type: string
         description: Contact person's phone number (optional).
+    additionalProperties: false
 required:
   - organizationIdentifier
   - justification
   - contact
+additionalProperties: false

--- a/src/schemas/models/Contact.yml
+++ b/src/schemas/models/Contact.yml
@@ -13,3 +13,4 @@ properties:
     type: string
     description: Phone number of the contact person.
     example: +49 30 12345678
+additionalProperties: false

--- a/src/schemas/models/Coordinates.yml
+++ b/src/schemas/models/Coordinates.yml
@@ -10,3 +10,7 @@ properties:
     type: string
     enum:
       - WGS84 (Decimal Degrees)
+required:
+  - latitude
+  - longitude
+additionalProperties: false

--- a/src/schemas/models/CreateAttractionRequest.yml
+++ b/src/schemas/models/CreateAttractionRequest.yml
@@ -1,9 +1,5 @@
 type: object
 properties:
-  type:
-    type: string
-    enum:
-      - type.Attraction
   title:
     $ref: "TranslatableField.yml"
   description:
@@ -28,5 +24,4 @@ properties:
       originObjectID:
         type: string
 required:
-  - type
   - title

--- a/src/schemas/models/CreateAttractionRequest.yml
+++ b/src/schemas/models/CreateAttractionRequest.yml
@@ -23,5 +23,7 @@ properties:
         type: string
       originObjectID:
         type: string
+    additionalProperties: false
 required:
   - title
+additionalProperties: false

--- a/src/schemas/models/CreateAttractionResponse.yml
+++ b/src/schemas/models/CreateAttractionResponse.yml
@@ -11,5 +11,7 @@ properties:
     properties:
       attractionReference:
         $ref: "Reference.yml"
+    additionalProperties: false
 required:
   - success
+additionalProperties: false

--- a/src/schemas/models/CreateEventRequest.yml
+++ b/src/schemas/models/CreateEventRequest.yml
@@ -37,3 +37,10 @@ properties:
         type: string
       originObjectID:
         type: string
+    additionalProperties: false
+required:
+  - schedule
+  - locations
+  - attractions
+  - organizer
+additionalProperties: false

--- a/src/schemas/models/CreateEventRequest.yml
+++ b/src/schemas/models/CreateEventRequest.yml
@@ -1,9 +1,5 @@
 type: object
 properties:
-  type:
-    type: string
-    enum:
-      - type.Event
   schedule:
     $ref: "Schedule.yml"
   title:
@@ -41,5 +37,3 @@ properties:
         type: string
       originObjectID:
         type: string
-required:
-  - type

--- a/src/schemas/models/CreateEventResponse.yml
+++ b/src/schemas/models/CreateEventResponse.yml
@@ -11,5 +11,7 @@ properties:
     properties:
       eventReference:
         $ref: "Reference.yml"
+    additionalProperties: false
 required:
   - success
+additionalProperties: false

--- a/src/schemas/models/CreateLocationRequest.yml
+++ b/src/schemas/models/CreateLocationRequest.yml
@@ -35,5 +35,7 @@ properties:
         type: string
       originObjectID:
         type: string
+    additionalProperties: false
 required:
   - title
+additionalProperties: false

--- a/src/schemas/models/CreateLocationRequest.yml
+++ b/src/schemas/models/CreateLocationRequest.yml
@@ -1,9 +1,5 @@
 type: object
 properties:
-  type:
-    type: string
-    enum:
-      - type.Location
   title:
     $ref: "TranslatableField.yml"
   description:
@@ -40,5 +36,4 @@ properties:
       originObjectID:
         type: string
 required:
-  - type
   - title

--- a/src/schemas/models/CreateLocationResponse.yml
+++ b/src/schemas/models/CreateLocationResponse.yml
@@ -11,5 +11,7 @@ properties:
     properties:
       locationReference:
         $ref: "Reference.yml"
+    additionalProperties: false
 required:
   - success
+additionalProperties: false

--- a/src/schemas/models/CreateOrganizationRequest.yml
+++ b/src/schemas/models/CreateOrganizationRequest.yml
@@ -27,5 +27,7 @@ properties:
         type: string
       originObjectID:
         type: string
+    additionalProperties: false
 required:
   - title
+additionalProperties: false

--- a/src/schemas/models/CreateOrganizationRequest.yml
+++ b/src/schemas/models/CreateOrganizationRequest.yml
@@ -1,9 +1,5 @@
 type: object
 properties:
-  type:
-    type: string
-    enum:
-      - type.Organization
   title:
     $ref: "TranslatableField.yml"
   description:
@@ -32,5 +28,4 @@ properties:
       originObjectID:
         type: string
 required:
-  - type
   - title

--- a/src/schemas/models/CreateOrganizationResponse.yml
+++ b/src/schemas/models/CreateOrganizationResponse.yml
@@ -10,5 +10,7 @@ properties:
     properties:
       organizationReference:
         $ref: "Reference.yml"
+    additionalProperties: false
 required:
   - success
+additionalProperties: false

--- a/src/schemas/models/CreateTagRequest.yml
+++ b/src/schemas/models/CreateTagRequest.yml
@@ -9,3 +9,4 @@ properties:
         type: object
 required:
   - title
+additionalProperties: false

--- a/src/schemas/models/CreateTagResponse.yml
+++ b/src/schemas/models/CreateTagResponse.yml
@@ -10,5 +10,7 @@ properties:
     properties:
       tag:
         $ref: "Tag.yml"
+    additionalProperties: false
 required:
   - success
+additionalProperties: false

--- a/src/schemas/models/CreateUserRequest.yml
+++ b/src/schemas/models/CreateUserRequest.yml
@@ -11,3 +11,4 @@ properties:
 required:
   - password
   - email
+additionalProperties: false

--- a/src/schemas/models/CreateUserResponse.yml
+++ b/src/schemas/models/CreateUserResponse.yml
@@ -10,5 +10,7 @@ properties:
     properties:
       userIdentifier:
         type: string
+    additionalProperties: false
 required:
   - success
+additionalProperties: false

--- a/src/schemas/models/DuplicateEventResponse.yml
+++ b/src/schemas/models/DuplicateEventResponse.yml
@@ -10,5 +10,7 @@ properties:
     properties:
       eventIdentifier:
         type: string
+    additionalProperties: false
 required:
   - success
+additionalProperties: false

--- a/src/schemas/models/EmailAlreadyInUseError.yml
+++ b/src/schemas/models/EmailAlreadyInUseError.yml
@@ -17,6 +17,8 @@ properties:
         type: string
     required:
       - code
+    additionalProperties: false
 required:
   - success
   - error
+additionalProperties: false

--- a/src/schemas/models/Error.yml
+++ b/src/schemas/models/Error.yml
@@ -6,3 +6,4 @@ properties:
     type: string
   details:
     type: string
+additionalProperties: false

--- a/src/schemas/models/Event.yml
+++ b/src/schemas/models/Event.yml
@@ -1,7 +1,4 @@
 type: object
-required:
-  - type
-  - identifier
 properties:
   type:
     type: string
@@ -55,3 +52,8 @@ properties:
     $ref: "Contact.yml"
   admission:
     $ref: "Admission.yml"
+required:
+  - type
+  - identifier
+  - metadata
+additionalProperties: false

--- a/src/schemas/models/Event.yml
+++ b/src/schemas/models/Event.yml
@@ -1,5 +1,6 @@
 type: object
 required:
+  - type
   - identifier
 properties:
   type:

--- a/src/schemas/models/ExternalLinks.yml
+++ b/src/schemas/models/ExternalLinks.yml
@@ -11,3 +11,4 @@ items:
       example: https://example.com/
   required:
     - url
+  additionalProperties: false

--- a/src/schemas/models/GetAdminAttractionResponse.yml
+++ b/src/schemas/models/GetAdminAttractionResponse.yml
@@ -9,5 +9,7 @@ properties:
     properties:
       attraction:
         $ref: "AdminAttraction.yml"
+    additionalProperties: false
 required:
   - success
+additionalProperties: false

--- a/src/schemas/models/GetAdminAttractionsResponse.yml
+++ b/src/schemas/models/GetAdminAttractionsResponse.yml
@@ -17,4 +17,4 @@ properties:
               $ref: "AdminAttraction.yml"
 required:
   - success
-  - data
+additionalProperties: false

--- a/src/schemas/models/GetAttractionResponse.yml
+++ b/src/schemas/models/GetAttractionResponse.yml
@@ -11,5 +11,7 @@ properties:
         $ref: "Attraction.yml"
       attractionReference:
         $ref: "Reference.yml"
+    additionalProperties: false
 required:
   - success
+additionalProperties: false

--- a/src/schemas/models/GetAttractionsResponse.yml
+++ b/src/schemas/models/GetAttractionsResponse.yml
@@ -19,3 +19,4 @@ properties:
               $ref: "Reference.yml"
 required:
   - success
+additionalProperties: false

--- a/src/schemas/models/GetEventResponse.yml
+++ b/src/schemas/models/GetEventResponse.yml
@@ -11,5 +11,7 @@ properties:
         $ref: "Event.yml"
       eventReference:
         $ref: "Reference.yml"
+    additionalProperties: false
 required:
   - success
+additionalProperties: false

--- a/src/schemas/models/GetEventsResponse.yml
+++ b/src/schemas/models/GetEventsResponse.yml
@@ -19,3 +19,4 @@ properties:
               $ref: "Reference.yml"
 required:
   - success
+additionalProperties: false

--- a/src/schemas/models/GetLocationResponse.yml
+++ b/src/schemas/models/GetLocationResponse.yml
@@ -11,5 +11,7 @@ properties:
         $ref: "Location.yml"
       locationReference:
         $ref: "Reference.yml"
+    additionalProperties: false
 required:
   - success
+additionalProperties: false

--- a/src/schemas/models/GetLocationsResponse.yml
+++ b/src/schemas/models/GetLocationsResponse.yml
@@ -19,3 +19,4 @@ properties:
               $ref: "Reference.yml"
 required:
   - success
+additionalProperties: false

--- a/src/schemas/models/GetOrganizationResponse.yml
+++ b/src/schemas/models/GetOrganizationResponse.yml
@@ -11,5 +11,7 @@ properties:
         $ref: "Organization.yml"
       organizationReference:
         $ref: "Reference.yml"
+    additionalProperties: false
 required:
   - success
+additionalProperties: false

--- a/src/schemas/models/GetOrganizationsResponse.yml
+++ b/src/schemas/models/GetOrganizationsResponse.yml
@@ -19,3 +19,4 @@ properties:
               $ref: "Reference.yml"
 required:
   - success
+additionalProperties: false

--- a/src/schemas/models/GetTagResponse.yml
+++ b/src/schemas/models/GetTagResponse.yml
@@ -9,5 +9,7 @@ properties:
     properties:
       tag:
         $ref: "Tag.yml"
+    additionalProperties: false
 required:
   - success
+additionalProperties: false

--- a/src/schemas/models/GetTagsResponse.yml
+++ b/src/schemas/models/GetTagsResponse.yml
@@ -11,5 +11,7 @@ properties:
         type: array
         items:
           $ref: "Tag.yml"
+    additionalProperties: false
 required:
   - success
+additionalProperties: false

--- a/src/schemas/models/GetUserResponse.yml
+++ b/src/schemas/models/GetUserResponse.yml
@@ -9,5 +9,7 @@ properties:
     properties:
       user:
         $ref: "User.yml"
+    additionalProperties: false
 required:
   - success
+additionalProperties: false

--- a/src/schemas/models/GetUsersResponse.yml
+++ b/src/schemas/models/GetUsersResponse.yml
@@ -15,3 +15,4 @@ properties:
               $ref: "User.yml"
 required:
   - success
+additionalProperties: false

--- a/src/schemas/models/HealthResponse.yml
+++ b/src/schemas/models/HealthResponse.yml
@@ -11,3 +11,7 @@ properties:
           type: string
         healthy:
           type: boolean
+      additionalProperties: false
+required:
+  - healthy
+additionalProperties: false

--- a/src/schemas/models/Location.yml
+++ b/src/schemas/models/Location.yml
@@ -1,7 +1,4 @@
 type: object
-required:
-  - type
-  - identifier
 properties:
   type:
     type: string
@@ -58,3 +55,9 @@ properties:
   contact:
     $ref: "Contact.yml"
     description: The main contact person of this location.
+required:
+  - type
+  - identifier
+  - metadata
+  - title
+additionalProperties: false

--- a/src/schemas/models/Location.yml
+++ b/src/schemas/models/Location.yml
@@ -1,5 +1,6 @@
 type: object
 required:
+  - type
   - identifier
 properties:
   type:

--- a/src/schemas/models/LoginRequest.yml
+++ b/src/schemas/models/LoginRequest.yml
@@ -1,6 +1,10 @@
 type: object
 properties:
-  password:
-    type: string
   email:
     type: string
+  password:
+    type: string
+required:
+  - email
+  - password
+additionalProperties: false

--- a/src/schemas/models/LoginResponse.yml
+++ b/src/schemas/models/LoginResponse.yml
@@ -6,10 +6,6 @@ properties:
     type: string
   data:
     type: object
-    required:
-      - accessToken
-      - expiresIn
-      - user
     properties:
       accessToken:
         type: string
@@ -17,5 +13,11 @@ properties:
         type: string
       user:
         $ref: "User.yml"
+    required:
+      - accessToken
+      - expiresIn
+      - user
+    additionalProperties: false
 required:
   - success
+additionalProperties: false

--- a/src/schemas/models/Metadata.yml
+++ b/src/schemas/models/Metadata.yml
@@ -1,7 +1,4 @@
 type: object
-required:
-  - created
-  - updated
 properties:
   created:
     type: string
@@ -24,3 +21,7 @@ properties:
     example: ["de", "en"]
     items:
       type: string
+required:
+  - created
+  - updated
+additionalProperties: false

--- a/src/schemas/models/OpeningHours.yml
+++ b/src/schemas/models/OpeningHours.yml
@@ -2,21 +2,26 @@ type: array
 items:
   type: object
   properties:
-    closes:
-      type: string
-      description: The closing hour of the place or service on the given day(s) of the week.
-      example: "22:00"
     dayOfWeek:
       type: string
       enum: [Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday]
       description: The day of the week for which these opening hours are valid.
     opens:
       type: string
-      description: The opening hour of the place or service on the given day(s) of the week.
+      description: The opening hour of the place or service on the given day of the week.
       example: "12:00"
+    closes:
+      type: string
+      description: The closing hour of the place or service on the given day of the week.
+      example: "22:00"
     validFrom:
       type: string
       description: The date when the item becomes valid.
     validThrough:
       type: string
       description: The date after when the item is not valid. For example the end of an offer, salary period, or a period of opening hours.
+  required:
+    - dayOfWeek
+    - opens
+    - closes
+  additionalProperties: false

--- a/src/schemas/models/Organization.yml
+++ b/src/schemas/models/Organization.yml
@@ -1,7 +1,4 @@
 type: object
-required:
-  - type
-  - identifier
 properties:
   type:
     type: string
@@ -44,3 +41,9 @@ properties:
     $ref: "Coordinates.yml"
   contact:
     $ref: "Contact.yml"
+required:
+  - type
+  - identifier
+  - metadata
+  - title
+additionalProperties: false

--- a/src/schemas/models/Organization.yml
+++ b/src/schemas/models/Organization.yml
@@ -1,5 +1,6 @@
 type: object
 required:
+  - type
   - identifier
 properties:
   type:

--- a/src/schemas/models/Reference.yml
+++ b/src/schemas/models/Reference.yml
@@ -6,3 +6,7 @@ properties:
     type: string
   referenceLabel:
     $ref: "TranslatableField.yml"
+required:
+  - referenceType
+  - referenceId
+additionalProperties: false

--- a/src/schemas/models/RemoveEventAttractionRequest.yml
+++ b/src/schemas/models/RemoveEventAttractionRequest.yml
@@ -4,3 +4,4 @@ properties:
     type: string
 required:
   - attractionIdentifier
+additionalProperties: false

--- a/src/schemas/models/RemoveEventLocationRequest.yml
+++ b/src/schemas/models/RemoveEventLocationRequest.yml
@@ -4,3 +4,4 @@ properties:
     type: string
 required:
   - locationIdentifier
+additionalProperties: false

--- a/src/schemas/models/RemoveExternalLinkRequest.yml
+++ b/src/schemas/models/RemoveExternalLinkRequest.yml
@@ -4,3 +4,4 @@ properties:
     type: string
 required:
   - url
+additionalProperties: false

--- a/src/schemas/models/RescheduleEventRequest.yml
+++ b/src/schemas/models/RescheduleEventRequest.yml
@@ -14,3 +14,4 @@ properties:
     type: string
   setToRescheduled:
     type: boolean
+additionalProperties: false

--- a/src/schemas/models/Response.yml
+++ b/src/schemas/models/Response.yml
@@ -10,3 +10,4 @@ properties:
     $ref: "Error.yml"
 required:
   - success
+additionalProperties: false

--- a/src/schemas/models/Schedule.yml
+++ b/src/schemas/models/Schedule.yml
@@ -24,3 +24,4 @@ properties:
     type: string
     description: The time the event end, in timezone Europe/Berlin.
     example: "22:00"
+additionalProperties: false

--- a/src/schemas/models/SearchAttractionsRequest.yml
+++ b/src/schemas/models/SearchAttractionsRequest.yml
@@ -3,3 +3,4 @@ properties:
   searchFilter:
     type: object
     additionalProperties: true
+additionalProperties: false

--- a/src/schemas/models/SearchEventsRequest.yml
+++ b/src/schemas/models/SearchEventsRequest.yml
@@ -14,6 +14,7 @@ properties:
           type: string
       matchMode:
         $ref: "MatchMode.yml"
+    additionalProperties: false
   byLocationAccessibilityTags:
     type: object
     properties:
@@ -23,5 +24,7 @@ properties:
           type: string
       matchMode:
         $ref: "MatchMode.yml"
+    additionalProperties: false
   inTheFuture:
     type: boolean
+additionalProperties: false

--- a/src/schemas/models/SearchLocationsRequest.yml
+++ b/src/schemas/models/SearchLocationsRequest.yml
@@ -3,3 +3,4 @@ properties:
   searchFilter:
     type: object
     additionalProperties: true
+additionalProperties: false

--- a/src/schemas/models/SearchOrganizationsRequest.yml
+++ b/src/schemas/models/SearchOrganizationsRequest.yml
@@ -3,3 +3,4 @@ properties:
   searchFilter:
     type: object
     additionalProperties: true
+additionalProperties: false

--- a/src/schemas/models/SearchTagsRequest.yml
+++ b/src/schemas/models/SearchTagsRequest.yml
@@ -3,3 +3,4 @@ properties:
   searchFilter:
     type: object
     additionalProperties: true
+additionalProperties: false

--- a/src/schemas/models/SetEventOrganizerRequest.yml
+++ b/src/schemas/models/SetEventOrganizerRequest.yml
@@ -4,3 +4,6 @@ properties:
     type: string
   alternativeDisplayName:
     $ref: "TranslatableField.yml"
+required:
+  - organizationIdentifier
+additionalProperties: false

--- a/src/schemas/models/SetLocationManagerRequest.yml
+++ b/src/schemas/models/SetLocationManagerRequest.yml
@@ -6,3 +6,4 @@ properties:
     $ref: "TranslatableField.yml"
 required:
   - organizationIdentifier
+additionalProperties: false

--- a/src/schemas/models/Tag.yml
+++ b/src/schemas/models/Tag.yml
@@ -18,5 +18,8 @@ properties:
             additionalProperties:
               type: string
 required:
+  - type
   - identifier
   - title
+  - metadata
+additionalProperties: false

--- a/src/schemas/models/UpdateAttractionRequest.yml
+++ b/src/schemas/models/UpdateAttractionRequest.yml
@@ -16,3 +16,4 @@ properties:
       type: string
   externalLinks:
     $ref: "ExternalLinks.yml"
+additionalProperties: false

--- a/src/schemas/models/UpdateEventRequest.yml
+++ b/src/schemas/models/UpdateEventRequest.yml
@@ -18,3 +18,4 @@ properties:
     $ref: "Contact.yml"
   admission:
     $ref: "Admission.yml"
+additionalProperties: false

--- a/src/schemas/models/UpdateLocationRequest.yml
+++ b/src/schemas/models/UpdateLocationRequest.yml
@@ -24,3 +24,4 @@ properties:
       $ref: "ExternalLinks.yml"
   contact:
     $ref: "Contact.yml"
+additionalProperties: false

--- a/src/schemas/models/UpdateOrganizationRequest.yml
+++ b/src/schemas/models/UpdateOrganizationRequest.yml
@@ -20,3 +20,4 @@ properties:
     $ref: "Coordinates.yml"
   contact:
     $ref: "Contact.yml"
+additionalProperties: false

--- a/src/schemas/models/UpdateUserPasswordRequest.yml
+++ b/src/schemas/models/UpdateUserPasswordRequest.yml
@@ -4,3 +4,7 @@ properties:
     type: string
   newPassword:
     type: string
+required:
+  - oneTimeCode
+  - newPassword
+additionalProperties: false

--- a/src/schemas/models/UpdateUserRequest.yml
+++ b/src/schemas/models/UpdateUserRequest.yml
@@ -6,3 +6,4 @@ properties:
     type: string
   lastName:
     type: string
+additionalProperties: false

--- a/src/schemas/models/User.yml
+++ b/src/schemas/models/User.yml
@@ -21,6 +21,10 @@ properties:
   permissionFlags:
     type: number
 required:
+  - type
   - identifier
   - email
+  - createdAt
+  - updatedAt
   - permissionFlags
+additionalProperties: false

--- a/src/scripts/schema-to-interface.ts
+++ b/src/scripts/schema-to-interface.ts
@@ -136,7 +136,7 @@ async function generateFaker(className: string, rootDirectory: string) {
 	import { ${className}, schemaFor${className} } from "../models/${className}.generated";
 ${dependencies.imports}
 
-	export function fake${className}(useExamples: boolean, specifiedPropertiesFor${className}: object = {}): ${className} {
+	export function fake${className}(useExamples: boolean, specifiedPropertiesFor${className}: Partial<${className}>): ${className} {
 		const schema = schemaFor${className} as Schema;
 		const refs : Schema[] = [
 ${dependencies.refs}
@@ -149,7 +149,7 @@ ${dependencies.refs}
 		return return${className};
 	}
 
-	export function fake${className}s(useExamples: boolean, ...create${className}: object[]) : ${className}[] {
+	export function fake${className}s(useExamples: boolean, ...create${className}: ${className}[]) : ${className}[] {
 		const return${className}s : ${className}[] = [];
 		create${className}.forEach(element => {
 			return${className}s.push(fake${className}(useExamples, element));

--- a/src/scripts/schema-to-interface.ts
+++ b/src/scripts/schema-to-interface.ts
@@ -33,20 +33,21 @@ async function generateInterface(className: string, rootDirectory: string) {
 		 * and run "npm run schema-to-interface" or "npm run generate" to regenerate this file.
 		 */
 
-		import Ajv, { ValidateFunction } from "ajv";
+		import Ajv, { ErrorObject } from "ajv";
 		import addFormats from "ajv-formats";
 		
 		 ${dependencies.imports}
 
 		 export const schemaFor${schemaName} = ${schema};
 
-		 export function validate${schemaName}(o : object): {isValid: boolean, validate: ValidateFunction} {
+		 export function validate${schemaName}(o : object): {isValid: boolean, errors: ErrorObject[]} {
 			const ajv = new Ajv();
 			addFormats(ajv);
 			ajv.addKeyword("example");
 			${dependencies.ajvSchema}
-			const validate = ajv.compile(schemaFor${schemaName});
-			return {isValid: validate(o), validate: validate};
+			const isValid = ajv.validate(schemaFor${schemaName}, o);
+			const errors = ajv.errors || [];
+			return { isValid, errors };
 		  }
 		`,
 		additionalProperties: false,


### PR DESCRIPTION
- Does no longer allow extra fields in all objects/entities (via `additionalProperties: false`) – otherwise, users could write their own extra fields straight into our database.
- More fields are required now:
  - `type` for all main entities (Attraction, Location, Organization, Event)
  - `metadata` for all main entities (Attraction, Location, Organization, Event)
  - `title` for most main entities (Attraction, Location, Organization)
  - some `identifier` fields (especially for add/update requests)
  - `email` and `password` in the `LoginRequest` model
  - `latitude` and `longitude` in the `Coordinates` model
  - `dayOfWeek`, `opens` and `closes` in the `OpeningHours` model
  - `referenceType` and `referenceId` in the `Reference` model
- All `type` fields are managed on the backend side --> No need to send `type` in creation requests anymore.
- Some smaller improvements for the schema-to-interface script.

⚠️ I would have loved to add a test for this strict request validation, but didn’t manage to get it running in our test environment so far.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205572230943098