### PR TITLE
feat: add linter for our OpenAPI file

### DIFF
--- a/.github/workflows/linter-and-typescript.yml
+++ b/.github/workflows/linter-and-typescript.yml
@@ -24,3 +24,5 @@ jobs:
         run: npm run lint
       - name: Run TypeScript compiler
         run: npm run typecheck
+      - name: Lint OpenAPI file
+        run: npm run lint-openapi

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ npm run format
 # Lint all code with ESLint
 npm run lint
 
+# Lint the generated OpenAPI file
+npm run lint-openapi
+
 # Run the TypeScript compiler to find any TypeScript errors
 npm run typecheck
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
 				"@babel/preset-env": "^7.20.2",
 				"@babel/preset-typescript": "^7.21.0",
 				"@faker-js/faker": "^8.0.0",
+				"@redocly/cli": "^1.2.0",
 				"@types/commander": "^2.12.2",
 				"@types/cors": "^2.8.13",
 				"@types/debug": "^4.1.7",
@@ -834,6 +835,66 @@
 			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 			"optional": true
 		},
+		"node_modules/@babel/cli": {
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.23.0.tgz",
+			"integrity": "sha512-17E1oSkGk2IwNILM4jtfAvgjt+ohmpfBky8aLerUfYZhiPNg7ca+CRCxZn8QDxwNhV/upsc2VHBCqGFIR+iBfA==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.17",
+				"commander": "^4.0.1",
+				"convert-source-map": "^2.0.0",
+				"fs-readdir-recursive": "^1.1.0",
+				"glob": "^7.2.0",
+				"make-dir": "^2.1.0",
+				"slash": "^2.0.0"
+			},
+			"bin": {
+				"babel": "bin/babel.js",
+				"babel-external-helpers": "bin/babel-external-helpers.js"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"optionalDependencies": {
+				"@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
+				"chokidar": "^3.4.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/cli/node_modules/commander": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+			"integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/@babel/cli/node_modules/make-dir": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+			"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+			"dev": true,
+			"dependencies": {
+				"pify": "^4.0.1",
+				"semver": "^5.6.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@babel/cli/node_modules/slash": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+			"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/@babel/code-frame": {
 			"version": "7.22.13",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
@@ -1349,6 +1410,38 @@
 				"@babel/core": "^7.13.0"
 			}
 		},
+		"node_modules/@babel/plugin-external-helpers": {
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-external-helpers/-/plugin-external-helpers-7.22.5.tgz",
+			"integrity": "sha512-ngnNEWxmykPk82mH4ajZT0qTztr3Je6hrMuKAslZVM8G1YZTENJSYwrIGtt6KOtznug3exmAtF4so/nPqJuA4A==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.22.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-proposal-class-properties": {
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz",
+			"integrity": "sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==",
+			"deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^7.18.6",
+				"@babel/helper-plugin-utils": "^7.18.6"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
 		"node_modules/@babel/plugin-proposal-decorators": {
 			"version": "7.23.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.23.0.tgz",
@@ -1360,6 +1453,26 @@
 				"@babel/helper-replace-supers": "^7.22.20",
 				"@babel/helper-split-export-declaration": "^7.22.6",
 				"@babel/plugin-syntax-decorators": "^7.22.10"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-proposal-object-rest-spread": {
+			"version": "7.20.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.20.7.tgz",
+			"integrity": "sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==",
+			"deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.",
+			"dev": true,
+			"dependencies": {
+				"@babel/compat-data": "^7.20.5",
+				"@babel/helper-compilation-targets": "^7.20.7",
+				"@babel/helper-plugin-utils": "^7.20.2",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+				"@babel/plugin-transform-parameters": "^7.20.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2274,6 +2387,71 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
+		"node_modules/@babel/plugin-transform-react-display-name": {
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.22.5.tgz",
+			"integrity": "sha512-PVk3WPYudRF5z4GKMEYUrLjPl38fJSKNaEOkFuoprioowGuWN6w2RKznuFNSlJx7pzzXXStPUnNSOEO0jL5EVw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.22.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-react-jsx": {
+			"version": "7.22.15",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.22.15.tgz",
+			"integrity": "sha512-oKckg2eZFa8771O/5vi7XeTvmM6+O9cxZu+kanTU7tD4sin5nO/G8jGJhq8Hvt2Z0kUoEDRayuZLaUlYl8QuGA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^7.22.5",
+				"@babel/helper-module-imports": "^7.22.15",
+				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/plugin-syntax-jsx": "^7.22.5",
+				"@babel/types": "^7.22.15"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-react-jsx-development": {
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.22.5.tgz",
+			"integrity": "sha512-bDhuzwWMuInwCYeDeMzyi7TaBgRQei6DqxhbyniL7/VG4RSS7HtSL2QbY4eESy1KJqlWt8g3xeEBGPuo+XqC8A==",
+			"dev": true,
+			"dependencies": {
+				"@babel/plugin-transform-react-jsx": "^7.22.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-react-pure-annotations": {
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.22.5.tgz",
+			"integrity": "sha512-gP4k85wx09q+brArVinTXhWiyzLl9UpmGva0+mWyKxk6JZequ05x3eUcIUE+FyttPKJFRRVtAvQaJ6YF9h1ZpA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.22.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
 		"node_modules/@babel/plugin-transform-regenerator": {
 			"version": "7.22.10",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.22.10.tgz",
@@ -2579,6 +2757,26 @@
 				"@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
 			}
 		},
+		"node_modules/@babel/preset-react": {
+			"version": "7.22.15",
+			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.22.15.tgz",
+			"integrity": "sha512-Csy1IJ2uEh/PecCBXXoZGAZBeCATTuePzCSB7dLYWS0vOEj6CNpjxIhW4duWwZodBNueH7QO14WbGn8YyeuN9w==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-validator-option": "^7.22.15",
+				"@babel/plugin-transform-react-display-name": "^7.22.5",
+				"@babel/plugin-transform-react-jsx": "^7.22.15",
+				"@babel/plugin-transform-react-jsx-development": "^7.22.5",
+				"@babel/plugin-transform-react-pure-annotations": "^7.22.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
 		"node_modules/@babel/preset-typescript": {
 			"version": "7.23.0",
 			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.23.0.tgz",
@@ -2727,6 +2925,27 @@
 				"kuler": "^2.0.0"
 			}
 		},
+		"node_modules/@emotion/is-prop-valid": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
+			"integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
+			"dev": true,
+			"dependencies": {
+				"@emotion/memoize": "^0.8.1"
+			}
+		},
+		"node_modules/@emotion/memoize": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+			"integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==",
+			"dev": true
+		},
+		"node_modules/@emotion/unitless": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
+			"integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==",
+			"dev": true
+		},
 		"node_modules/@eslint-community/eslint-utils": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -2831,6 +3050,12 @@
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
+		},
+		"node_modules/@exodus/schemasafe": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.3.0.tgz",
+			"integrity": "sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==",
+			"dev": true
 		},
 		"node_modules/@faker-js/faker": {
 			"version": "8.1.0",
@@ -3788,6 +4013,13 @@
 				"sparse-bitfield": "^3.0.3"
 			}
 		},
+		"node_modules/@nicolo-ribaudo/chokidar-2": {
+			"version": "2.1.8-no-fsevents.3",
+			"resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
+			"integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
+			"dev": true,
+			"optional": true
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3866,6 +4098,153 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
 			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
 			"dev": true
+		},
+		"node_modules/@redocly/ajv": {
+			"version": "8.11.0",
+			"resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.0.tgz",
+			"integrity": "sha512-9GWx27t7xWhDIR02PA18nzBdLcKQRgc46xNQvjFkrYk4UOmvKhJ/dawwiX0cCOeetN5LcaaiqQbVOWYK62SGHw==",
+			"dev": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/@redocly/cli": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-1.2.0.tgz",
+			"integrity": "sha512-xfZuRcdDAeal9gyP5Frbmw3R6/HsW7Nh29tiR2b22Cqi/xD5W8wIZw78/1a6rUTfmqrofKdpNUAmSMywbb0Y+g==",
+			"dev": true,
+			"dependencies": {
+				"@redocly/openapi-core": "1.2.0",
+				"chokidar": "^3.5.1",
+				"colorette": "^1.2.0",
+				"core-js": "^3.32.1",
+				"get-port-please": "^3.0.1",
+				"glob": "^7.1.6",
+				"handlebars": "^4.7.6",
+				"mobx": "^6.0.4",
+				"react": "^17.0.0 || ^18.2.0",
+				"react-dom": "^17.0.0 || ^18.2.0",
+				"redoc": "~2.1.2",
+				"semver": "^7.5.2",
+				"simple-websocket": "^9.0.0",
+				"styled-components": "^6.0.7",
+				"yargs": "17.0.1"
+			},
+			"bin": {
+				"openapi": "bin/cli.js",
+				"redocly": "bin/cli.js"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@redocly/cli/node_modules/cliui": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"dev": true,
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^7.0.0"
+			}
+		},
+		"node_modules/@redocly/cli/node_modules/semver": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@redocly/cli/node_modules/yargs": {
+			"version": "17.0.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.0.1.tgz",
+			"integrity": "sha512-xBBulfCc8Y6gLFcrPvtqKz9hz8SO0l1Ni8GgDekvBX2ro0HRQImDGnikfc33cgzcYUSncapnNcZDjVFIH3f6KQ==",
+			"dev": true,
+			"dependencies": {
+				"cliui": "^7.0.2",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^20.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@redocly/cli/node_modules/yargs-parser": {
+			"version": "20.2.9",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@redocly/openapi-core": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.2.0.tgz",
+			"integrity": "sha512-Ccft2n/JiF4u2crmj1cdDzPq6C40U7NgLZ+p/BxzAFXbfrddr/5FN0HMJPHT/op329qqv2P2jUrXsV2Bp+rzEQ==",
+			"dev": true,
+			"dependencies": {
+				"@redocly/ajv": "^8.11.0",
+				"@types/node": "^14.11.8",
+				"colorette": "^1.2.0",
+				"js-levenshtein": "^1.1.6",
+				"js-yaml": "^4.1.0",
+				"lodash.isequal": "^4.5.0",
+				"minimatch": "^5.0.1",
+				"node-fetch": "^2.6.1",
+				"pluralize": "^8.0.0",
+				"yaml-ast-parser": "0.0.43"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@redocly/openapi-core/node_modules/@types/node": {
+			"version": "14.18.63",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+			"integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+			"dev": true
+		},
+		"node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/@redocly/openapi-core/node_modules/minimatch": {
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/@sinclair/typebox": {
 			"version": "0.27.8",
@@ -5041,6 +5420,12 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
 			"integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+			"dev": true
+		},
+		"node_modules/@types/stylis": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.1.tgz",
+			"integrity": "sha512-OSaMrXUKxVigGlKRrET39V2xdhzlztQ9Aqumn1WbCBKHOi9ry7jKSd7rkyj0GzmWaU960Rd+LpOFpLfx5bMQAg==",
 			"dev": true
 		},
 		"node_modules/@types/superagent": {
@@ -6443,6 +6828,15 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/camelize": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+			"integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/caniuse-lite": {
 			"version": "1.0.30001525",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001525.tgz",
@@ -6541,6 +6935,12 @@
 			"integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
 			"dev": true
 		},
+		"node_modules/classnames": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+			"integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==",
+			"dev": true
+		},
 		"node_modules/cli-color": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.3.tgz",
@@ -6569,6 +6969,15 @@
 			},
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/clsx": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+			"integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/co": {
@@ -6624,6 +7033,12 @@
 			"bin": {
 				"color-support": "bin.js"
 			}
+		},
+		"node_modules/colorette": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+			"integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+			"dev": true
 		},
 		"node_modules/colorspace": {
 			"version": "1.1.4",
@@ -6759,6 +7174,17 @@
 			"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
 			"integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
 			"dev": true
+		},
+		"node_modules/core-js": {
+			"version": "3.33.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.0.tgz",
+			"integrity": "sha512-HoZr92+ZjFEKar5HS6MC776gYslNOKHt75mEBKWKnPeFDpZ6nH5OeF3S6HFT1mUAUZKrzkez05VboaX8myjSuw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/core-js"
+			}
 		},
 		"node_modules/core-js-compat": {
 			"version": "3.32.1",
@@ -6900,6 +7326,32 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/css-color-keywords": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+			"integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/css-to-react-native": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+			"integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+			"dev": true,
+			"dependencies": {
+				"camelize": "^1.0.0",
+				"css-color-keywords": "^1.0.0",
+				"postcss-value-parser": "^4.0.2"
+			}
+		},
+		"node_modules/csstype": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+			"integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
+			"dev": true
+		},
 		"node_modules/d": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
@@ -6925,6 +7377,12 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/decko": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decko/-/decko-1.2.0.tgz",
+			"integrity": "sha512-m8FnyHXV1QX+S1cl+KPFDIl6NMkxtKsy6+U/aYyjrOqWMuwAwYWu7ePqrsUHtDR5Y8Yk2pi/KIDSgF+vT4cPOQ==",
+			"dev": true
 		},
 		"node_modules/dedent": {
 			"version": "1.5.1",
@@ -7225,6 +7683,12 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/dompurify": {
+			"version": "2.4.7",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.7.tgz",
+			"integrity": "sha512-kxxKlPEDa6Nc5WJi+qRgPbOAbgTpSULL+vI3NUXsZMlkJxTqYI9wg5ZTay2sFrdZRWHPWNi+EdAhcJf81WtoMQ==",
+			"dev": true
+		},
 		"node_modules/dotenv": {
 			"version": "16.3.1",
 			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
@@ -7433,6 +7897,12 @@
 				"es5-ext": "^0.10.35",
 				"es6-symbol": "^3.1.1"
 			}
+		},
+		"node_modules/es6-promise": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+			"integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==",
+			"dev": true
 		},
 		"node_modules/es6-symbol": {
 			"version": "3.1.3",
@@ -7987,6 +8457,12 @@
 				"es5-ext": "~0.10.14"
 			}
 		},
+		"node_modules/eventemitter3": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+			"dev": true
+		},
 		"node_modules/execa": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -8440,6 +8916,12 @@
 				"is-callable": "^1.1.3"
 			}
 		},
+		"node_modules/foreach": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.6.tgz",
+			"integrity": "sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg==",
+			"dev": true
+		},
 		"node_modules/foreground-child": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
@@ -8545,6 +9027,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/fs-readdir-recursive": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+			"dev": true
 		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
@@ -8668,6 +9156,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/get-port-please": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.1.1.tgz",
+			"integrity": "sha512-3UBAyM3u4ZBVYDsxOQfJDxEa6XTbpBDrOjp4mf7ExFRt5BKs/QywQQiJsh2B+hxcZLSapWqCRvElUe8DnKcFHA==",
+			"dev": true
 		},
 		"node_modules/get-stdin": {
 			"version": "8.0.0",
@@ -8827,6 +9321,27 @@
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
 			"dev": true
 		},
+		"node_modules/handlebars": {
+			"version": "4.7.8",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+			"integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+			"dev": true,
+			"dependencies": {
+				"minimist": "^1.2.5",
+				"neo-async": "^2.6.2",
+				"source-map": "^0.6.1",
+				"wordwrap": "^1.0.0"
+			},
+			"bin": {
+				"handlebars": "bin/handlebars"
+			},
+			"engines": {
+				"node": ">=0.4.7"
+			},
+			"optionalDependencies": {
+				"uglify-js": "^3.1.4"
+			}
+		},
 		"node_modules/has": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -8938,6 +9453,12 @@
 			"engines": {
 				"node": ">= 0.8"
 			}
+		},
+		"node_modules/http2-client": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.5.tgz",
+			"integrity": "sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==",
+			"dev": true
 		},
 		"node_modules/https-proxy-agent": {
 			"version": "5.0.1",
@@ -11167,6 +11688,15 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
+		"node_modules/js-levenshtein": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+			"integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11207,6 +11737,15 @@
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
 			"dev": true
+		},
+		"node_modules/json-pointer": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.2.tgz",
+			"integrity": "sha512-vLWcKbOaXlO+jvRy4qNd+TI1QUPZzfJj1tpJ3vAXDych5XJf93ftpUKe5pKCrzyIIwgBJcOcCVRUfqQP25afBw==",
+			"dev": true,
+			"dependencies": {
+				"foreach": "^2.0.4"
+			}
 		},
 		"node_modules/json-schema-faker": {
 			"version": "0.5.3",
@@ -11483,6 +12022,12 @@
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
 			"integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
 		},
+		"node_modules/lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+			"dev": true
+		},
 		"node_modules/lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -11518,6 +12063,18 @@
 				"triple-beam": "^1.3.0"
 			}
 		},
+		"node_modules/loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"dev": true,
+			"dependencies": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			},
+			"bin": {
+				"loose-envify": "cli.js"
+			}
+		},
 		"node_modules/lru-cache": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -11537,6 +12094,12 @@
 			"dependencies": {
 				"es5-ext": "~0.10.2"
 			}
+		},
+		"node_modules/lunr": {
+			"version": "2.3.9",
+			"resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+			"integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+			"dev": true
 		},
 		"node_modules/make-dir": {
 			"version": "3.1.0",
@@ -11572,6 +12135,24 @@
 			"dev": true,
 			"dependencies": {
 				"tmpl": "1.0.5"
+			}
+		},
+		"node_modules/mark.js": {
+			"version": "8.11.1",
+			"resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+			"integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+			"dev": true
+		},
+		"node_modules/marked": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+			"integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+			"dev": true,
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 12"
 			}
 		},
 		"node_modules/md5-file": {
@@ -11754,6 +12335,63 @@
 			},
 			"bin": {
 				"mkdirp": "bin/cmd.js"
+			}
+		},
+		"node_modules/mobx": {
+			"version": "6.10.2",
+			"resolved": "https://registry.npmjs.org/mobx/-/mobx-6.10.2.tgz",
+			"integrity": "sha512-B1UGC3ieK3boCjnMEcZSwxqRDMdzX65H/8zOHbuTY8ZhvrIjTUoLRR2TP2bPqIgYRfb3+dUigu8yMZufNjn0LQ==",
+			"dev": true,
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mobx"
+			}
+		},
+		"node_modules/mobx-react": {
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/mobx-react/-/mobx-react-7.6.0.tgz",
+			"integrity": "sha512-+HQUNuh7AoQ9ZnU6c4rvbiVVl+wEkb9WqYsVDzGLng+Dqj1XntHu79PvEWKtSMoMj67vFp/ZPXcElosuJO8ckA==",
+			"dev": true,
+			"dependencies": {
+				"mobx-react-lite": "^3.4.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mobx"
+			},
+			"peerDependencies": {
+				"mobx": "^6.1.0",
+				"react": "^16.8.0 || ^17 || ^18"
+			},
+			"peerDependenciesMeta": {
+				"react-dom": {
+					"optional": true
+				},
+				"react-native": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/mobx-react-lite": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-3.4.3.tgz",
+			"integrity": "sha512-NkJREyFTSUXR772Qaai51BnE1voWx56LOL80xG7qkZr6vo8vEaLF3sz1JNUVh+rxmUzxYaqOhfuxTfqUh0FXUg==",
+			"dev": true,
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mobx"
+			},
+			"peerDependencies": {
+				"mobx": "^6.1.0",
+				"react": "^16.8.0 || ^17 || ^18"
+			},
+			"peerDependenciesMeta": {
+				"react-dom": {
+					"optional": true
+				},
+				"react-native": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/mongodb": {
@@ -12014,6 +12652,12 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/neo-async": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+			"dev": true
+		},
 		"node_modules/new-find-package-json": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-2.0.0.tgz",
@@ -12056,11 +12700,32 @@
 				}
 			}
 		},
+		"node_modules/node-fetch-h2": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz",
+			"integrity": "sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==",
+			"dev": true,
+			"dependencies": {
+				"http2-client": "^1.2.5"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			}
+		},
 		"node_modules/node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
 			"integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
 			"dev": true
+		},
+		"node_modules/node-readfiles": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
+			"integrity": "sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==",
+			"dev": true,
+			"dependencies": {
+				"es6-promise": "^3.2.1"
+			}
 		},
 		"node_modules/node-releases": {
 			"version": "2.0.13",
@@ -12164,6 +12829,76 @@
 				"console-control-strings": "^1.1.0",
 				"gauge": "^3.0.0",
 				"set-blocking": "^2.0.0"
+			}
+		},
+		"node_modules/oas-kit-common": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/oas-kit-common/-/oas-kit-common-1.0.8.tgz",
+			"integrity": "sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==",
+			"dev": true,
+			"dependencies": {
+				"fast-safe-stringify": "^2.0.7"
+			}
+		},
+		"node_modules/oas-linter": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/oas-linter/-/oas-linter-3.2.2.tgz",
+			"integrity": "sha512-KEGjPDVoU5K6swgo9hJVA/qYGlwfbFx+Kg2QB/kd7rzV5N8N5Mg6PlsoCMohVnQmo+pzJap/F610qTodKzecGQ==",
+			"dev": true,
+			"dependencies": {
+				"@exodus/schemasafe": "^1.0.0-rc.2",
+				"should": "^13.2.1",
+				"yaml": "^1.10.0"
+			},
+			"funding": {
+				"url": "https://github.com/Mermade/oas-kit?sponsor=1"
+			}
+		},
+		"node_modules/oas-resolver": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/oas-resolver/-/oas-resolver-2.5.6.tgz",
+			"integrity": "sha512-Yx5PWQNZomfEhPPOphFbZKi9W93CocQj18NlD2Pa4GWZzdZpSJvYwoiuurRI7m3SpcChrnO08hkuQDL3FGsVFQ==",
+			"dev": true,
+			"dependencies": {
+				"node-fetch-h2": "^2.3.0",
+				"oas-kit-common": "^1.0.8",
+				"reftools": "^1.1.9",
+				"yaml": "^1.10.0",
+				"yargs": "^17.0.1"
+			},
+			"bin": {
+				"resolve": "resolve.js"
+			},
+			"funding": {
+				"url": "https://github.com/Mermade/oas-kit?sponsor=1"
+			}
+		},
+		"node_modules/oas-schema-walker": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/oas-schema-walker/-/oas-schema-walker-1.1.5.tgz",
+			"integrity": "sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/Mermade/oas-kit?sponsor=1"
+			}
+		},
+		"node_modules/oas-validator": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/oas-validator/-/oas-validator-5.0.8.tgz",
+			"integrity": "sha512-cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw==",
+			"dev": true,
+			"dependencies": {
+				"call-me-maybe": "^1.0.1",
+				"oas-kit-common": "^1.0.8",
+				"oas-linter": "^3.2.2",
+				"oas-resolver": "^2.5.6",
+				"oas-schema-walker": "^1.1.5",
+				"reftools": "^1.1.9",
+				"should": "^13.2.1",
+				"yaml": "^1.10.0"
+			},
+			"funding": {
+				"url": "https://github.com/Mermade/oas-kit?sponsor=1"
 			}
 		},
 		"node_modules/object-assign": {
@@ -12323,6 +13058,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/openapi-sampler": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.3.1.tgz",
+			"integrity": "sha512-Ert9mvc2tLPmmInwSyGZS+v4Ogu9/YoZuq9oP3EdUklg2cad6+IGndP9yqJJwbgdXwZibiq5fpv6vYujchdJFg==",
+			"dev": true,
+			"dependencies": {
+				"@types/json-schema": "^7.0.7",
+				"json-pointer": "0.6.2"
+			}
+		},
 		"node_modules/optionator": {
 			"version": "0.9.3",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -12476,6 +13221,12 @@
 				"node": ">= 0.4.0"
 			}
 		},
+		"node_modules/path-browserify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+			"integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+			"dev": true
+		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -12558,6 +13309,12 @@
 			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
 			"dev": true
 		},
+		"node_modules/perfect-scrollbar": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/perfect-scrollbar/-/perfect-scrollbar-1.5.5.tgz",
+			"integrity": "sha512-dzalfutyP3e/FOpdlhVryN4AJ5XDVauVWxybSkLZmakFE2sS3y3pc4JnSprw8tGmHvkaG5Edr5T7LBTZ+WWU2g==",
+			"dev": true
+		},
 		"node_modules/picocolors": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -12574,6 +13331,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/pify": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/pirates": {
@@ -12596,6 +13362,61 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/pluralize": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+			"integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/polished": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/polished/-/polished-4.2.2.tgz",
+			"integrity": "sha512-Sz2Lkdxz6F2Pgnpi9U5Ng/WdWAUZxmHrNPoVlm3aAemxoy2Qy7LGjQg4uf8qKelDAUW94F4np3iH2YPf2qefcQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.17.8"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/postcss": {
+			"version": "8.4.31",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+			"integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"dependencies": {
+				"nanoid": "^3.3.6",
+				"picocolors": "^1.0.0",
+				"source-map-js": "^1.0.2"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/postcss-value-parser": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+			"dev": true
 		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
@@ -12660,6 +13481,15 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
+		"node_modules/prismjs": {
+			"version": "1.29.0",
+			"resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
+			"integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -12677,6 +13507,23 @@
 			"engines": {
 				"node": ">= 6"
 			}
+		},
+		"node_modules/prop-types": {
+			"version": "15.8.1",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+			"dev": true,
+			"dependencies": {
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.13.1"
+			}
+		},
+		"node_modules/prop-types/node_modules/react-is": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+			"dev": true
 		},
 		"node_modules/proxy-addr": {
 			"version": "2.0.7",
@@ -12759,6 +13606,15 @@
 				}
 			]
 		},
+		"node_modules/randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"dev": true,
+			"dependencies": {
+				"safe-buffer": "^5.1.0"
+			}
+		},
 		"node_modules/range-parser": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -12781,11 +13637,49 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/react": {
+			"version": "18.2.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+			"integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+			"dev": true,
+			"dependencies": {
+				"loose-envify": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/react-dom": {
+			"version": "18.2.0",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+			"integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+			"dev": true,
+			"dependencies": {
+				"loose-envify": "^1.1.0",
+				"scheduler": "^0.23.0"
+			},
+			"peerDependencies": {
+				"react": "^18.2.0"
+			}
+		},
 		"node_modules/react-is": {
 			"version": "18.2.0",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
 			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
 			"dev": true
+		},
+		"node_modules/react-tabs": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-4.3.0.tgz",
+			"integrity": "sha512-2GfoG+f41kiBIIyd3gF+/GRCCYtamC8/2zlAcD8cqQmqI9Q+YVz7fJLHMmU9pXDVYYHpJeCgUSBJju85vu5q8Q==",
+			"dev": true,
+			"dependencies": {
+				"clsx": "^1.1.0",
+				"prop-types": "^15.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-0 || ^18.0.0"
+			}
 		},
 		"node_modules/readable-stream": {
 			"version": "3.6.0",
@@ -12812,10 +13706,59 @@
 				"node": ">=8.10.0"
 			}
 		},
+		"node_modules/redoc": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/redoc/-/redoc-2.1.2.tgz",
+			"integrity": "sha512-pTu+aTdyJAMPVnOBYMesEjvRnh51BKE7bFLDIM6DiUSigli+3LfandSEp2FaaGnoqyvvC9axg/dvKQP16s02ww==",
+			"dev": true,
+			"dependencies": {
+				"@redocly/openapi-core": "^1.0.0-rc.2",
+				"classnames": "^2.3.1",
+				"decko": "^1.2.0",
+				"dompurify": "^2.2.8",
+				"eventemitter3": "^4.0.7",
+				"json-pointer": "^0.6.2",
+				"lunr": "^2.3.9",
+				"mark.js": "^8.11.1",
+				"marked": "^4.0.15",
+				"mobx-react": "^7.2.0",
+				"openapi-sampler": "^1.3.1",
+				"path-browserify": "^1.0.1",
+				"perfect-scrollbar": "^1.5.5",
+				"polished": "^4.1.3",
+				"prismjs": "^1.27.0",
+				"prop-types": "^15.7.2",
+				"react-tabs": "^4.3.0",
+				"slugify": "~1.4.7",
+				"stickyfill": "^1.1.1",
+				"swagger2openapi": "^7.0.6",
+				"url-template": "^2.0.8"
+			},
+			"engines": {
+				"node": ">=6.9",
+				"npm": ">=3.0.0"
+			},
+			"peerDependencies": {
+				"core-js": "^3.1.4",
+				"mobx": "^6.0.4",
+				"react": "^16.8.4 || ^17.0.0 || ^18.0.0",
+				"react-dom": "^16.8.4 || ^17.0.0 || ^18.0.0",
+				"styled-components": "^4.1.1 || ^5.1.1 || ^6.0.5"
+			}
+		},
 		"node_modules/reflect-metadata": {
 			"version": "0.1.13",
 			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
 			"integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+		},
+		"node_modules/reftools": {
+			"version": "1.1.9",
+			"resolved": "https://registry.npmjs.org/reftools/-/reftools-1.1.9.tgz",
+			"integrity": "sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/Mermade/oas-kit?sponsor=1"
+			}
 		},
 		"node_modules/regenerate": {
 			"version": "1.4.2",
@@ -13151,6 +14094,15 @@
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
+		"node_modules/scheduler": {
+			"version": "0.23.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+			"integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+			"dev": true,
+			"dependencies": {
+				"loose-envify": "^1.1.0"
+			}
+		},
 		"node_modules/semver": {
 			"version": "5.7.2",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
@@ -13225,6 +14177,12 @@
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
 			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
 		},
+		"node_modules/shallowequal": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+			"integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+			"dev": true
+		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -13245,6 +14203,60 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/should": {
+			"version": "13.2.3",
+			"resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
+			"integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
+			"dev": true,
+			"dependencies": {
+				"should-equal": "^2.0.0",
+				"should-format": "^3.0.3",
+				"should-type": "^1.4.0",
+				"should-type-adaptors": "^1.0.1",
+				"should-util": "^1.0.0"
+			}
+		},
+		"node_modules/should-equal": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+			"integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
+			"dev": true,
+			"dependencies": {
+				"should-type": "^1.4.0"
+			}
+		},
+		"node_modules/should-format": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+			"integrity": "sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==",
+			"dev": true,
+			"dependencies": {
+				"should-type": "^1.3.0",
+				"should-type-adaptors": "^1.0.1"
+			}
+		},
+		"node_modules/should-type": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+			"integrity": "sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ==",
+			"dev": true
+		},
+		"node_modules/should-type-adaptors": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+			"integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
+			"dev": true,
+			"dependencies": {
+				"should-type": "^1.3.0",
+				"should-util": "^1.0.0"
+			}
+		},
+		"node_modules/should-util": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
+			"integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
+			"dev": true
 		},
 		"node_modules/side-channel": {
 			"version": "1.0.4",
@@ -13299,6 +14311,33 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/simple-websocket": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/simple-websocket/-/simple-websocket-9.1.0.tgz",
+			"integrity": "sha512-8MJPnjRN6A8UCp1I+H/dSFyjwJhp6wta4hsVRhjf8w9qBHRzxYt14RaOcjvQnhD1N4yKOddEjflwMnQM4VtXjQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"debug": "^4.3.1",
+				"queue-microtask": "^1.2.2",
+				"randombytes": "^2.1.0",
+				"readable-stream": "^3.6.0",
+				"ws": "^7.4.2"
+			}
+		},
 		"node_modules/sisteransi": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -13320,6 +14359,15 @@
 			"integrity": "sha512-fXjhAZszNecz855GUNIwW0+sFPi9WV4bMiEKDOCA4wcq1ts1UnUVNy/F78B0Aat7/W3rA+se//33ILKNMrbeYQ==",
 			"bin": {
 				"slug": "cli.js"
+			}
+		},
+		"node_modules/slugify": {
+			"version": "1.4.7",
+			"resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.7.tgz",
+			"integrity": "sha512-tf+h5W1IrjNm/9rKKj0JU2MDMruiopx0jjVA5zCdBtcGjfp0+c5rHw/zADLC3IeKlGHtVbHtpfzvYA0OYT+HKg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/smart-buffer": {
@@ -13350,6 +14398,15 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/source-map-js": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -13414,6 +14471,12 @@
 			"engines": {
 				"node": ">= 0.8"
 			}
+		},
+		"node_modules/stickyfill": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stickyfill/-/stickyfill-1.1.1.tgz",
+			"integrity": "sha512-GCp7vHAfpao+Qh/3Flh9DXEJ/qSi0KJwJw6zYlZOtRYXWUIpMM6mC2rIep/dK8RQqwW0KxGJIllmjPIBOGN8AA==",
+			"dev": true
 		},
 		"node_modules/streamsearch": {
 			"version": "1.1.0",
@@ -13577,6 +14640,62 @@
 			"integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
 			"optional": true
 		},
+		"node_modules/styled-components": {
+			"version": "6.0.8",
+			"resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.0.8.tgz",
+			"integrity": "sha512-AwI02MTWZwqjzfXgR5QcbmcSn5xVjY4N2TLjSuYnmuBGF3y7GicHz3ysbpUq2EMJP5M8/Nc22vcmF3V3WNZDFA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/cli": "^7.21.0",
+				"@babel/core": "^7.21.0",
+				"@babel/helper-module-imports": "^7.18.6",
+				"@babel/plugin-external-helpers": "^7.18.6",
+				"@babel/plugin-proposal-class-properties": "^7.18.6",
+				"@babel/plugin-proposal-object-rest-spread": "^7.20.7",
+				"@babel/preset-env": "^7.20.2",
+				"@babel/preset-react": "^7.18.6",
+				"@babel/preset-typescript": "^7.21.0",
+				"@babel/traverse": "^7.21.2",
+				"@emotion/is-prop-valid": "^1.2.1",
+				"@emotion/unitless": "^0.8.0",
+				"@types/stylis": "^4.0.2",
+				"css-to-react-native": "^3.2.0",
+				"csstype": "^3.1.2",
+				"postcss": "^8.4.23",
+				"shallowequal": "^1.1.0",
+				"stylis": "^4.3.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/styled-components"
+			},
+			"peerDependencies": {
+				"babel-plugin-styled-components": ">= 2",
+				"react": ">= 16.8.0",
+				"react-dom": ">= 16.8.0"
+			},
+			"peerDependenciesMeta": {
+				"babel-plugin-styled-components": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/styled-components/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+			"dev": true
+		},
+		"node_modules/stylis": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.0.tgz",
+			"integrity": "sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ==",
+			"dev": true
+		},
 		"node_modules/superagent": {
 			"version": "8.0.9",
 			"resolved": "https://registry.npmjs.org/superagent/-/superagent-8.0.9.tgz",
@@ -13703,6 +14822,33 @@
 			},
 			"peerDependencies": {
 				"express": ">=4.0.0 || >=5.0.0-beta"
+			}
+		},
+		"node_modules/swagger2openapi": {
+			"version": "7.0.8",
+			"resolved": "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-7.0.8.tgz",
+			"integrity": "sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g==",
+			"dev": true,
+			"dependencies": {
+				"call-me-maybe": "^1.0.1",
+				"node-fetch": "^2.6.1",
+				"node-fetch-h2": "^2.3.0",
+				"node-readfiles": "^0.2.0",
+				"oas-kit-common": "^1.0.8",
+				"oas-resolver": "^2.5.6",
+				"oas-schema-walker": "^1.1.5",
+				"oas-validator": "^5.0.8",
+				"reftools": "^1.1.9",
+				"yaml": "^1.10.0",
+				"yargs": "^17.0.1"
+			},
+			"bin": {
+				"boast": "boast.js",
+				"oas-validate": "oas-validate.js",
+				"swagger2openapi": "swagger2openapi.js"
+			},
+			"funding": {
+				"url": "https://github.com/Mermade/oas-kit?sponsor=1"
 			}
 		},
 		"node_modules/synckit": {
@@ -14279,6 +15425,19 @@
 				"node": ">=14.17"
 			}
 		},
+		"node_modules/uglify-js": {
+			"version": "3.17.4",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+			"integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+			"dev": true,
+			"optional": true,
+			"bin": {
+				"uglifyjs": "bin/uglifyjs"
+			},
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
 		"node_modules/unbox-primitive": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -14394,6 +15553,12 @@
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
+		},
+		"node_modules/url-template": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+			"integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+			"dev": true
 		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
@@ -14573,6 +15738,12 @@
 				"node": ">= 6.4.0"
 			}
 		},
+		"node_modules/wordwrap": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+			"dev": true
+		},
 		"node_modules/wrap-ansi": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -14692,6 +15863,27 @@
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
+		"node_modules/ws": {
+			"version": "7.5.9",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8.3.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/xtend": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -14713,6 +15905,21 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+		},
+		"node_modules/yaml": {
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/yaml-ast-parser": {
+			"version": "0.0.43",
+			"resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
+			"integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
+			"dev": true
 		},
 		"node_modules/yamljs": {
 			"version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	"scripts": {
 		"format": "prettier --write .",
 		"lint": "eslint .",
+		"lint-openapi": "redocly lint ./src/schemas/kulturdaten.berlin.openapi.generated.yml",
 		"typecheck": "tsc --noEmit",
 		"dev": "nodemon --inspect",
 		"start": "ts-node ./src/app.ts",
@@ -67,6 +68,7 @@
 		"@babel/preset-env": "^7.20.2",
 		"@babel/preset-typescript": "^7.21.0",
 		"@faker-js/faker": "^8.0.0",
+		"@redocly/cli": "^1.2.0",
 		"@types/commander": "^2.12.2",
 		"@types/cors": "^2.8.13",
 		"@types/debug": "^4.1.7",

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -1,0 +1,10 @@
+extends:
+  - recommended
+
+rules:
+  no-unused-components: off
+  no-server-trailing-slash: off
+  operation-4xx-response: off
+  operation-operationId: off
+  operation-summary: off
+  security-defined: off


### PR DESCRIPTION
This adds a linter script powered by [Redocly CLI](https://redocly.com/docs/cli/) to our scripts and runs it on the GitHub CI as well. This way, we should always enforce a valid OpenAPI file before merging. (Our express server also validates the file when it starts, but now the validation happens without starting the server explicitly and also blocks merging of invalid schemas.)