### PR TITLE
refactor: make all status fields required and add default values

### DIFF
--- a/src/admin/districtData/services/DistrictDataMapper.ts
+++ b/src/admin/districtData/services/DistrictDataMapper.ts
@@ -84,10 +84,10 @@ export class DistrictDataMapper {
 	): CreateEventRequest {
 		return {
 			schedule: {
-				...(termin.tag_von && { startDate: termin.tag_von }),
-				...(termin.tag_bis && { endDate: termin.tag_bis }),
-				...(termin.uhrzeit_von && { startTime: termin.uhrzeit_von }),
-				...(termin.uhrzeit_bis && { endTime: termin.uhrzeit_bis }),
+				startDate: termin.tag_von,
+				endDate: termin.tag_bis,
+				startTime: termin.uhrzeit_von,
+				endTime: termin.uhrzeit_bis,
 			},
 			attractions: [attractionReference],
 			locations: [locationReference],

--- a/src/resources/attractions/repositories/MongoDBAttractionsRepository.ts
+++ b/src/resources/attractions/repositories/MongoDBAttractionsRepository.ts
@@ -50,6 +50,7 @@ export class MongoDBAttractionsRepository implements AttractionsRepository {
 			...createAttraction,
 			type: "type.Attraction",
 			identifier: generateAttractionID(),
+			status: "attraction.published",
 			metadata: createMetadata(createAttraction.metadata),
 		};
 		const attractions = await this.dbConnector.attractions();

--- a/src/resources/events/repositories/MongoDBEventsRepository.ts
+++ b/src/resources/events/repositories/MongoDBEventsRepository.ts
@@ -59,6 +59,8 @@ export class MongoDBEventsRepository implements EventsRepository {
 			...createEvent,
 			type: "type.Event",
 			identifier: generateEventID(),
+			status: "event.published",
+			scheduleStatus: "event.scheduled",
 			metadata: createMetadata(createEvent.metadata),
 		};
 		const events = await this.dbConnector.events();

--- a/src/resources/events/services/EventsService.unit.test.ts
+++ b/src/resources/events/services/EventsService.unit.test.ts
@@ -2,179 +2,61 @@ import { mock } from "ts-mockito";
 import { Event } from "../../../generated/models/Event.generated";
 import { EventsRepository } from "../repositories/EventsRepository";
 import { EventsService } from "./EventsService";
-import { Metadata } from "../../../generated/models/Metadata.generated";
 
-const fakeMetadata: Metadata = {
-	created: "2023-10-02T15:33:41.146Z",
-	updated: "2023-10-02T15:33:41.146Z",
-};
+function createEvent(identifier: string) {
+	const event: Event = {
+		identifier,
+		type: "type.Event",
+		metadata: {
+			created: "2023-10-02T15:33:41.146Z",
+			updated: "2023-10-02T15:33:41.146Z",
+		},
+		status: "event.published",
+		scheduleStatus: "event.scheduled",
+		locations: [],
+		attractions: [],
+		organizer: {
+			referenceType: "type.Organizer",
+			referenceId: "asdfgh",
+		},
+	};
+	return event;
+}
 
 describe("test intersection and removeDuplicates", () => {
 	it(" should return the intersection of two event arrays ", async () => {
-		const eventsA: Event[] = [
-			{
-				type: "type.Event",
-				identifier: "1",
-				metadata: fakeMetadata,
-			},
-			{
-				type: "type.Event",
-				identifier: "2",
-				metadata: fakeMetadata,
-			},
-		];
-		const eventsB: Event[] = [
-			{
-				type: "type.Event",
-				identifier: "2",
-				metadata: fakeMetadata,
-			},
-			{
-				type: "type.Event",
-				identifier: "3",
-				metadata: fakeMetadata,
-			},
-		];
-
-		const eventService: EventsService = new EventsService(mock<EventsRepository>());
-
-		expect(eventService.getIntersection(eventsA, eventsB)).toStrictEqual([
-			{
-				type: "type.Event",
-				identifier: "2",
-				metadata: fakeMetadata,
-			},
-		]);
+		const eventsA = [createEvent("1"), createEvent("2")];
+		const eventsB = [createEvent("2"), createEvent("3")];
+		const eventService = new EventsService(mock<EventsRepository>());
+		expect(eventService.getIntersection(eventsA, eventsB)).toStrictEqual([createEvent("2")]);
 	});
 
 	it(" should return all events without duplicates", async () => {
-		const eventsA: Event[] = [
-			{
-				type: "type.Event",
-				identifier: "1",
-				metadata: fakeMetadata,
-			},
-			{
-				type: "type.Event",
-				identifier: "2",
-				metadata: fakeMetadata,
-			},
-		];
-		const eventsB: Event[] = [
-			{
-				type: "type.Event",
-				identifier: "2",
-				metadata: fakeMetadata,
-			},
-			{
-				type: "type.Event",
-				identifier: "3",
-				metadata: fakeMetadata,
-			},
-		];
-
-		const eventService: EventsService = new EventsService(mock<EventsRepository>());
-
+		const eventsA = [createEvent("1"), createEvent("2")];
+		const eventsB = [createEvent("2"), createEvent("3")];
+		const eventService = new EventsService(mock<EventsRepository>());
 		expect(eventService.removeDuplicates([...eventsA, ...eventsB])).toStrictEqual([
-			{
-				type: "type.Event",
-				identifier: "1",
-				metadata: fakeMetadata,
-			},
-			{
-				type: "type.Event",
-				identifier: "2",
-				metadata: fakeMetadata,
-			},
-			{
-				type: "type.Event",
-				identifier: "3",
-				metadata: fakeMetadata,
-			},
+			createEvent("1"),
+			createEvent("2"),
+			createEvent("3"),
 		]);
 	});
 
 	it(' MatchMode "any" should return all events without duplicates', async () => {
-		const eventsA: Event[] = [
-			{
-				type: "type.Event",
-				identifier: "1",
-				metadata: fakeMetadata,
-			},
-			{
-				type: "type.Event",
-				identifier: "2",
-				metadata: fakeMetadata,
-			},
-		];
-		const eventsB: Event[] = [
-			{
-				type: "type.Event",
-				identifier: "2",
-				metadata: fakeMetadata,
-			},
-			{
-				type: "type.Event",
-				identifier: "3",
-				metadata: fakeMetadata,
-			},
-		];
-
-		const eventService: EventsService = new EventsService(mock<EventsRepository>());
-
+		const eventsA: Event[] = [createEvent("1"), createEvent("2")];
+		const eventsB: Event[] = [createEvent("2"), createEvent("3")];
+		const eventService = new EventsService(mock<EventsRepository>());
 		expect(eventService.match(eventsA, eventsB, "any")).toStrictEqual([
-			{
-				type: "type.Event",
-				identifier: "1",
-				metadata: fakeMetadata,
-			},
-			{
-				type: "type.Event",
-				identifier: "2",
-				metadata: fakeMetadata,
-			},
-			{
-				type: "type.Event",
-				identifier: "3",
-				metadata: fakeMetadata,
-			},
+			createEvent("1"),
+			createEvent("2"),
+			createEvent("3"),
 		]);
 	});
 
 	it(' MatchMode "all" should return the intersection of two event arrays ', async () => {
-		const eventsA: Event[] = [
-			{
-				type: "type.Event",
-				identifier: "1",
-				metadata: fakeMetadata,
-			},
-			{
-				type: "type.Event",
-				identifier: "2",
-				metadata: fakeMetadata,
-			},
-		];
-		const eventsB: Event[] = [
-			{
-				type: "type.Event",
-				identifier: "2",
-				metadata: fakeMetadata,
-			},
-			{
-				type: "type.Event",
-				identifier: "3",
-				metadata: fakeMetadata,
-			},
-		];
-
-		const eventService: EventsService = new EventsService(mock<EventsRepository>());
-
-		expect(eventService.match(eventsA, eventsB, "all")).toStrictEqual([
-			{
-				type: "type.Event",
-				identifier: "2",
-				metadata: fakeMetadata,
-			},
-		]);
+		const eventsA: Event[] = [createEvent("1"), createEvent("2")];
+		const eventsB: Event[] = [createEvent("2"), createEvent("3")];
+		const eventService = new EventsService(mock<EventsRepository>());
+		expect(eventService.match(eventsA, eventsB, "all")).toStrictEqual([createEvent("2")]);
 	});
 });

--- a/src/resources/locations/repositories/MongoDBLocationsRepository.ts
+++ b/src/resources/locations/repositories/MongoDBLocationsRepository.ts
@@ -45,6 +45,8 @@ export class MongoDBLocationsRepository implements LocationsRepository {
 			...createLocation,
 			type: "type.Location",
 			identifier: generateLocationID(),
+			status: "location.published",
+			openingStatus: "location.opened",
 			metadata: createMetadata(createLocation.metadata),
 		};
 		const result = await locations.insertOne(newLocation);

--- a/src/resources/organizations/repositories/MongoDBOrganizationsRepository.ts
+++ b/src/resources/organizations/repositories/MongoDBOrganizationsRepository.ts
@@ -62,6 +62,8 @@ export class MongoDBOrganizationsRepository implements OrganizationsRepository {
 			...createOrganization,
 			type: "type.Organization",
 			identifier: generateOrganizationID(),
+			status: "organization.published",
+			activationStatus: "organization.active",
 			metadata: createMetadata(createOrganization.metadata),
 		};
 		const organizations = await this.dbConnector.organizations();

--- a/src/schemas/kulturdaten.berlin.openapi.generated.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.generated.yml
@@ -1647,6 +1647,9 @@ components:
               type: string
               description: The time the event end, in timezone Europe/Berlin.
               example: "22:00"
+          required:
+            - startDate
+            - startTime
           additionalProperties: false
         title:
           type: object
@@ -1812,6 +1815,8 @@ components:
         - type
         - identifier
         - metadata
+        - status
+        - scheduleStatus
       additionalProperties: false
     AdminAttraction:
       type: object
@@ -1996,6 +2001,9 @@ components:
                     type: string
                     description: The time the event end, in timezone Europe/Berlin.
                     example: "22:00"
+                required:
+                  - startDate
+                  - startTime
                 additionalProperties: false
               title:
                 type: object
@@ -2161,6 +2169,8 @@ components:
               - type
               - identifier
               - metadata
+              - status
+              - scheduleStatus
             additionalProperties: false
         externalLinks:
           type: array
@@ -2292,6 +2302,7 @@ components:
         - type
         - identifier
         - metadata
+        - status
         - title
       additionalProperties: false
     Location:
@@ -2540,7 +2551,9 @@ components:
         - type
         - identifier
         - metadata
+        - status
         - title
+        - openingStatus
       additionalProperties: false
     Organization:
       type: object
@@ -2706,6 +2719,8 @@ components:
         - type
         - identifier
         - metadata
+        - status
+        - activationStatus
         - title
       additionalProperties: false
     User:
@@ -2955,6 +2970,8 @@ components:
                 - type
                 - identifier
                 - metadata
+                - status
+                - activationStatus
                 - title
               additionalProperties: false
             organizationReference:
@@ -3183,6 +3200,8 @@ components:
                       - type
                       - identifier
                       - metadata
+                      - status
+                      - activationStatus
                       - title
                     additionalProperties: false
                 organizationsReferences:
@@ -3575,6 +3594,8 @@ components:
                       - type
                       - identifier
                       - metadata
+                      - status
+                      - activationStatus
                       - title
                     additionalProperties: false
                 organizationsReferences:
@@ -3860,6 +3881,7 @@ components:
                       - type
                       - identifier
                       - metadata
+                      - status
                       - title
                     additionalProperties: false
                 attractionsReferences:
@@ -4152,6 +4174,7 @@ components:
                       - type
                       - identifier
                       - metadata
+                      - status
                       - title
                     additionalProperties: false
                 attractionsReferences:
@@ -4303,6 +4326,7 @@ components:
                 - type
                 - identifier
                 - metadata
+                - status
                 - title
               additionalProperties: false
             attractionReference:
@@ -4680,7 +4704,9 @@ components:
                       - type
                       - identifier
                       - metadata
+                      - status
                       - title
+                      - openingStatus
                     additionalProperties: false
                 locationsReferences:
                   type: array
@@ -5238,7 +5264,9 @@ components:
                       - type
                       - identifier
                       - metadata
+                      - status
                       - title
+                      - openingStatus
                     additionalProperties: false
                 locationsReferences:
                   type: array
@@ -5528,7 +5556,9 @@ components:
                 - type
                 - identifier
                 - metadata
+                - status
                 - title
+                - openingStatus
               additionalProperties: false
             locationReference:
               type: object
@@ -5856,6 +5886,9 @@ components:
                             type: string
                             description: The time the event end, in timezone Europe/Berlin.
                             example: "22:00"
+                        required:
+                          - startDate
+                          - startTime
                         additionalProperties: false
                       title:
                         type: object
@@ -6027,6 +6060,8 @@ components:
                       - type
                       - identifier
                       - metadata
+                      - status
+                      - scheduleStatus
                     additionalProperties: false
                 eventsReferences:
                   type: array
@@ -6092,6 +6127,9 @@ components:
               type: string
               description: The time the event end, in timezone Europe/Berlin.
               example: "22:00"
+          required:
+            - startDate
+            - startTime
           additionalProperties: false
         title:
           type: object
@@ -6471,6 +6509,9 @@ components:
                             type: string
                             description: The time the event end, in timezone Europe/Berlin.
                             example: "22:00"
+                        required:
+                          - startDate
+                          - startTime
                         additionalProperties: false
                       title:
                         type: object
@@ -6642,6 +6683,8 @@ components:
                       - type
                       - identifier
                       - metadata
+                      - status
+                      - scheduleStatus
                     additionalProperties: false
                 eventsReferences:
                   type: array
@@ -6771,6 +6814,9 @@ components:
                       type: string
                       description: The time the event end, in timezone Europe/Berlin.
                       example: "22:00"
+                  required:
+                    - startDate
+                    - startTime
                   additionalProperties: false
                 title:
                   type: object
@@ -6936,6 +6982,8 @@ components:
                 - type
                 - identifier
                 - metadata
+                - status
+                - scheduleStatus
               additionalProperties: false
             eventReference:
               type: object
@@ -7145,6 +7193,9 @@ components:
           type: string
         setToRescheduled:
           type: boolean
+      required:
+        - startDate
+        - startTime
       additionalProperties: false
     DuplicateEventResponse:
       properties:
@@ -7888,6 +7939,9 @@ components:
                             type: string
                             description: The time the event end, in timezone Europe/Berlin.
                             example: "22:00"
+                        required:
+                          - startDate
+                          - startTime
                         additionalProperties: false
                       title:
                         type: object
@@ -8059,6 +8113,8 @@ components:
                       - type
                       - identifier
                       - metadata
+                      - status
+                      - scheduleStatus
                     additionalProperties: false
                 externalLinks:
                   type: array
@@ -8318,6 +8374,9 @@ components:
                                     The time the event end, in timezone
                                     Europe/Berlin.
                                   example: "22:00"
+                              required:
+                                - startDate
+                                - startTime
                               additionalProperties: false
                             title:
                               type: object
@@ -8492,6 +8551,8 @@ components:
                             - type
                             - identifier
                             - metadata
+                            - status
+                            - scheduleStatus
                           additionalProperties: false
                       externalLinks:
                         type: array

--- a/src/schemas/models/Attraction.yml
+++ b/src/schemas/models/Attraction.yml
@@ -47,5 +47,6 @@ required:
   - type
   - identifier
   - metadata
+  - status
   - title
 additionalProperties: false

--- a/src/schemas/models/Event.yml
+++ b/src/schemas/models/Event.yml
@@ -56,4 +56,6 @@ required:
   - type
   - identifier
   - metadata
+  - status
+  - scheduleStatus
 additionalProperties: false

--- a/src/schemas/models/Location.yml
+++ b/src/schemas/models/Location.yml
@@ -59,5 +59,7 @@ required:
   - type
   - identifier
   - metadata
+  - status
   - title
+  - openingStatus
 additionalProperties: false

--- a/src/schemas/models/Organization.yml
+++ b/src/schemas/models/Organization.yml
@@ -45,5 +45,7 @@ required:
   - type
   - identifier
   - metadata
+  - status
+  - activationStatus
   - title
 additionalProperties: false

--- a/src/schemas/models/RescheduleEventRequest.yml
+++ b/src/schemas/models/RescheduleEventRequest.yml
@@ -14,4 +14,7 @@ properties:
     type: string
   setToRescheduled:
     type: boolean
+required:
+  - startDate
+  - startTime
 additionalProperties: false

--- a/src/schemas/models/Schedule.yml
+++ b/src/schemas/models/Schedule.yml
@@ -24,4 +24,7 @@ properties:
     type: string
     description: The time the event end, in timezone Europe/Berlin.
     example: "22:00"
+required:
+  - startDate
+  - startTime
 additionalProperties: false


### PR DESCRIPTION
Makes all status-related fields required and adds default values (i.e. "published" or "scheduled").

Also makes `startDate` and `startTime` inside `Schedule` required.