### PR TITLE
chore: update servers in schema file

### DIFF
--- a/redocly.yaml
+++ b/redocly.yaml
@@ -3,7 +3,6 @@ extends:
 
 rules:
   no-unused-components: off
-  no-server-trailing-slash: off
   operation-4xx-response: off
   operation-operationId: off
   operation-summary: off

--- a/src/schemas/kulturdaten.berlin.openapi.base.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.base.yml
@@ -59,6 +59,8 @@ servers:
   - url: http://localhost:3000/api/
     description: Local development server
   - url: https://api-v2.kulturdaten.berlin/api/
+  - url: https://kulturdaten-api-staging.onrender.com/api
+    description: Staging server
     description: Production server
 tags:
   - name: Discover cultural data

--- a/src/schemas/kulturdaten.berlin.openapi.base.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.base.yml
@@ -54,13 +54,13 @@ info:
     name: MIT
     url: https://github.com/technologiestiftung/kulturdaten-api/LICENSE
 servers:
-  - url: /api/
+  - url: /api
     description: This server
-  - url: http://localhost:3000/api/
+  - url: http://localhost:3000/api
     description: Local development server
-  - url: https://api-v2.kulturdaten.berlin/api/
   - url: https://kulturdaten-api-staging.onrender.com/api
     description: Staging server
+  - url: https://api-v2.kulturdaten.berlin/api
     description: Production server
 tags:
   - name: Discover cultural data

--- a/src/schemas/kulturdaten.berlin.openapi.generated.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.generated.yml
@@ -88,13 +88,13 @@ info:
     name: MIT
     url: https://github.com/technologiestiftung/kulturdaten-api/LICENSE
 servers:
-  - url: /api/
+  - url: /api
     description: This server
-  - url: http://localhost:3000/api/
+  - url: http://localhost:3000/api
     description: Local development server
-  - url: https://api-v2.kulturdaten.berlin/api/
   - url: https://kulturdaten-api-staging.onrender.com/api
     description: Staging server
+  - url: https://api-v2.kulturdaten.berlin/api
     description: Production server
 tags:
   - name: Discover cultural data

--- a/src/schemas/kulturdaten.berlin.openapi.generated.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.generated.yml
@@ -93,6 +93,8 @@ servers:
   - url: http://localhost:3000/api/
     description: Local development server
   - url: https://api-v2.kulturdaten.berlin/api/
+  - url: https://kulturdaten-api-staging.onrender.com/api
+    description: Staging server
     description: Production server
 tags:
   - name: Discover cultural data


### PR DESCRIPTION
- adds our new staging server to the server list in schema
- removes trailing slashes from servers in schema (we had a warning in our schema linter redocly-cli about this)