### PR TITLE
fix: make status field in AdminAttraction required

### DIFF
--- a/src/schemas/kulturdaten.berlin.openapi.generated.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.generated.yml
@@ -2191,6 +2191,7 @@ components:
         - type
         - identifier
         - metadata
+        - status
         - title
         - events
       additionalProperties: false
@@ -8135,6 +8136,7 @@ components:
                 - type
                 - identifier
                 - metadata
+                - status
                 - title
                 - events
               additionalProperties: false
@@ -8573,6 +8575,7 @@ components:
                       - type
                       - identifier
                       - metadata
+                      - status
                       - title
                       - events
                     additionalProperties: false

--- a/src/schemas/models/AdminAttraction.yml
+++ b/src/schemas/models/AdminAttraction.yml
@@ -38,6 +38,7 @@ required:
   - type
   - identifier
   - metadata
+  - status
   - title
   - events
 additionalProperties: false


### PR DESCRIPTION
Makes the `status` field in the `AdminAttraction` model required as well (as with `Attraction`). This was overlooked in the other status PR (https://github.com/technologiestiftung/kulturdaten-api/pull/69).