### PR TITLE
fix: add house number to harvester’s streetAddress parsing

### DIFF
--- a/src/admin/districtData/services/DistrictDataMapper.ts
+++ b/src/admin/districtData/services/DistrictDataMapper.ts
@@ -1,3 +1,4 @@
+import { Address } from "../../../generated/models/Address.generated";
 import { Borough } from "../../../generated/models/Borough.generated";
 import { CreateAttractionRequest } from "../../../generated/models/CreateAttractionRequest.generated";
 import { CreateEventRequest } from "../../../generated/models/CreateEventRequest.generated";
@@ -128,11 +129,7 @@ export class DistrictDataMapper {
 
 		return {
 			title: { de: veranstaltungsort.name },
-			address: {
-				...(veranstaltungsort.strasse && { streetAddress: veranstaltungsort.strasse }),
-				...(veranstaltungsort.plz && { postalCode: veranstaltungsort.plz }),
-				...(veranstaltungsort.ort && { addressLocality: veranstaltungsort.ort }),
-			},
+			address: this.mapAddress(veranstaltungsort),
 			...(veranstaltungsort.telefon && { contact: { telephone: veranstaltungsort.telefon } }),
 			...(accessibilityTags && { accessibility: accessibilityTags }),
 			...(boroughOfLocation && { borough: boroughOfLocation }),
@@ -140,6 +137,14 @@ export class DistrictDataMapper {
 				origin: "bezirkskalender",
 				originObjectID: String(veranstaltungsort.id),
 			},
+		};
+	}
+
+	mapAddress(veranstaltungsort: Veranstaltungsort): Address {
+		return {
+			...(veranstaltungsort.strasse && { streetAddress: veranstaltungsort.strasse }),
+			...(veranstaltungsort.plz && { postalCode: veranstaltungsort.plz }),
+			...(veranstaltungsort.ort && { addressLocality: veranstaltungsort.ort }),
 		};
 	}
 

--- a/src/admin/districtData/services/DistrictDataMapper.ts
+++ b/src/admin/districtData/services/DistrictDataMapper.ts
@@ -141,8 +141,9 @@ export class DistrictDataMapper {
 	}
 
 	mapAddress(veranstaltungsort: Veranstaltungsort): Address {
+		const streetAddress = `${veranstaltungsort.strasse.trim()} ${veranstaltungsort.hausnummer}`.trim();
 		return {
-			...(veranstaltungsort.strasse && { streetAddress: veranstaltungsort.strasse }),
+			...(streetAddress && { streetAddress }),
 			...(veranstaltungsort.plz && { postalCode: veranstaltungsort.plz }),
 			...(veranstaltungsort.ort && { addressLocality: veranstaltungsort.ort }),
 		};


### PR DESCRIPTION
Externalizes the `streetAddress` generation into a new function and adds the `hausnummer` field, so that we always have full street addresses in the `streetAddress` field.

⚠️ After this is merged, we should re-harvest all data on staging and production.

P.S.: The `trim()` on `veranstaltungsort.strasse` is needed because some Bezirkskalender data has an extra space at the end.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205842659548321