### PR TITLE
Feat: add starting organization to seed script

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ npm start
 
 ## Initializing an empty database
 
-The `Seeder.ts` script assists in initializing your database. Use the `-t` or `--tags` flag to add predefined tags. To set up an admin user, utilize the `-a` or `--admin` flag followed by the credentials in the format `email:password`. Both operations can be performed simultaneously in one command. For example:
+The `Seeder.ts` script assists in initializing your database. Use the `-t` or `--tags` flag to add predefined tags. To set up an admin user, utilize the `-a` or `--admin` flag followed by the credentials in the format `email:password`. To set up a starting organization (TSB), utilize the `-o` or `-organization` flag. All operations can be performed simultaneously in one command. For example:
 
 ```shell
-npm run seed -- --tags --admin admin@example.com:password123
+npm run seed -- --tags --admin admin@example.com:password123 --organization
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ npm start
 
 ## Initializing an empty database
 
-The `Seeder.ts` script assists in initializing your database. Use the `-t` or `--tags` flag to add predefined tags. To set up an admin user, utilize the `-a` or `--admin` flag followed by the credentials in the format `email:password`. To set up a starting organization (TSB), utilize the `-o` or `-organization` flag. All operations can be performed simultaneously in one command. For example:
+The `Seeder.ts` script assists in initializing your database. Use the `-t` or `--tags` flag to add predefined tags. To set up a starting organization (TSB), utilize the `-o` or `-organization` flag. To set up an admin user and them to the organization, utilize the `-a` or `--admin` flag followed by the credentials in the format `email:password`. All operations can be performed simultaneously in one command. For example:
 
 ```shell
-npm run seed -- --tags --admin admin@example.com:password123 --organization
+npm run seed -- --tags --organization --admin admin@example.com:password123
 ```
 
 

--- a/src/scripts/seeder.ts
+++ b/src/scripts/seeder.ts
@@ -37,9 +37,18 @@ let mongoDBConnector: MongoDBConnector;
  *  npm run seed -- --tags
  *
  * ---------------------------
+ * Setting up an Organization:
+ * ---------------------------
+ * To create a starting organization (TSB) and add the admin as a member with the admin role, use the
+ * `-o` or `--organization` flag. The admin user will only be added to this organization if they are created
+ * with the same command.
+ * Example:
+ *  npm run seed -- --organization --admin admin@example.com:password123
+ *
+ * ---------------------------
  * Creating an Admin User:
  * ---------------------------
- * To introduce an admin user to the database, apply the `-a` or `--admin` flag.
+ * To introduce an admin user to the database (without an organization), use the `-a` or `--admin` flag.
  * This should be followed by the user's email and password, structured as `email:password`.
  * Example:
  *  npm run seed -- --admin admin@example.com:password123


### PR DESCRIPTION
Adds a new `--organization` (or `-o`) parameter to our seed script, which creates an initial TSB organization and adds the admin to that organization (via `memberships`).

This should help with setting up the initial database and have a more helpful starting point.