### PR TITLE
Feat/introduce virtual locations

### DIFF
--- a/src/admin/districtData/services/DistrictDataMapper.ts
+++ b/src/admin/districtData/services/DistrictDataMapper.ts
@@ -129,6 +129,7 @@ export class DistrictDataMapper {
 
 		return {
 			title: { de: veranstaltungsort.name },
+			isVirtual: false,
 			address: this.mapAddress(veranstaltungsort),
 			...(veranstaltungsort.telefon && { contact: { telephone: veranstaltungsort.telefon } }),
 			...(accessibilityTags && { accessibility: accessibilityTags }),

--- a/src/schemas/kulturdaten.berlin.openapi.generated.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.generated.yml
@@ -2636,6 +2636,10 @@ components:
           example: https://example.com/
         isVirtual:
           type: boolean
+          description: >-
+            Indicates that the place exists only in a digital format and can be
+            accessed or experienced online, rather than being a physical
+            location in the real world.
         address:
           type: object
           properties:
@@ -4960,6 +4964,11 @@ components:
                         example: https://example.com/
                       isVirtual:
                         type: boolean
+                        description: >-
+                          Indicates that the place exists only in a digital
+                          format and can be accessed or experienced online,
+                          rather than being a physical location in the real
+                          world.
                       address:
                         type: object
                         properties:
@@ -5197,6 +5206,10 @@ components:
           type: string
         isVirtual:
           type: boolean
+          description: >-
+            Indicates that the place exists only in a digital format and can be
+            accessed or experienced online, rather than being a physical
+            location in the real world.
         address:
           type: object
           properties:
@@ -5528,6 +5541,11 @@ components:
                         example: https://example.com/
                       isVirtual:
                         type: boolean
+                        description: >-
+                          Indicates that the place exists only in a digital
+                          format and can be accessed or experienced online,
+                          rather than being a physical location in the real
+                          world.
                       address:
                         type: object
                         properties:
@@ -5827,6 +5845,10 @@ components:
                   example: https://example.com/
                 isVirtual:
                   type: boolean
+                  description: >-
+                    Indicates that the place exists only in a digital format and
+                    can be accessed or experienced online, rather than being a
+                    physical location in the real world.
                 address:
                   type: object
                   properties:
@@ -6062,6 +6084,10 @@ components:
           type: string
         isVirtual:
           type: boolean
+          description: >-
+            Indicates that the place exists only in a digital format and can be
+            accessed or experienced online, rather than being a physical
+            location in the real world.
         address:
           type: object
           properties:

--- a/src/schemas/kulturdaten.berlin.openapi.generated.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.generated.yml
@@ -2634,6 +2634,8 @@ components:
         website:
           type: string
           example: https://example.com/
+        isVirtual:
+          type: boolean
         address:
           type: object
           properties:
@@ -4956,6 +4958,8 @@ components:
                       website:
                         type: string
                         example: https://example.com/
+                      isVirtual:
+                        type: boolean
                       address:
                         type: object
                         properties:
@@ -5191,6 +5195,8 @@ components:
             en: concert
         website:
           type: string
+        isVirtual:
+          type: boolean
         address:
           type: object
           properties:
@@ -5520,6 +5526,8 @@ components:
                       website:
                         type: string
                         example: https://example.com/
+                      isVirtual:
+                        type: boolean
                       address:
                         type: object
                         properties:
@@ -5817,6 +5825,8 @@ components:
                 website:
                   type: string
                   example: https://example.com/
+                isVirtual:
+                  type: boolean
                 address:
                   type: object
                   properties:
@@ -6050,6 +6060,8 @@ components:
             en: concert
         website:
           type: string
+        isVirtual:
+          type: boolean
         address:
           type: object
           properties:

--- a/src/schemas/models/CreateLocationRequest.yml
+++ b/src/schemas/models/CreateLocationRequest.yml
@@ -8,6 +8,7 @@ properties:
     type: string
   isVirtual:
     type: boolean
+    description: Indicates that the place exists only in a digital format and can be accessed or experienced online, rather than being a physical location in the real world.
   address:
     $ref: "Address.yml"
   borough:

--- a/src/schemas/models/CreateLocationRequest.yml
+++ b/src/schemas/models/CreateLocationRequest.yml
@@ -6,6 +6,8 @@ properties:
     $ref: "TranslatableField.yml"
   website:
     type: string
+  isVirtual:
+    type: boolean
   address:
     $ref: "Address.yml"
   borough:

--- a/src/schemas/models/Location.yml
+++ b/src/schemas/models/Location.yml
@@ -21,6 +21,8 @@ properties:
   website:
     type: string
     example: https://example.com/
+  isVirtual:
+    type: boolean
   address:
     $ref: "Address.yml"
   borough:

--- a/src/schemas/models/Location.yml
+++ b/src/schemas/models/Location.yml
@@ -23,6 +23,7 @@ properties:
     example: https://example.com/
   isVirtual:
     type: boolean
+    description: Indicates that the place exists only in a digital format and can be accessed or experienced online, rather than being a physical location in the real world.
   address:
     $ref: "Address.yml"
   borough:

--- a/src/schemas/models/UpdateLocationRequest.yml
+++ b/src/schemas/models/UpdateLocationRequest.yml
@@ -8,6 +8,7 @@ properties:
     type: string
   isVirtual:
     type: boolean
+    description: Indicates that the place exists only in a digital format and can be accessed or experienced online, rather than being a physical location in the real world.
   address:
     $ref: "Address.yml"
   borough:

--- a/src/schemas/models/UpdateLocationRequest.yml
+++ b/src/schemas/models/UpdateLocationRequest.yml
@@ -6,6 +6,8 @@ properties:
     $ref: "TranslatableField.yml"
   website:
     type: string
+  isVirtual:
+    type: boolean
   address:
     $ref: "Address.yml"
   borough:


### PR DESCRIPTION
Einfach gehalten. Ein Flag ohne weitere Funktionalität. Dinge wie automatisch serverseitig eine Adresse löschen finde ich zu disruptiv. Dies kann auf Seiten der UI gemacht werden. Aber auch hier könnte die Adresse nur ausgeblendet werden - satt sie zu löschen. Einfacher umzusetzen - und spart Arbeit, falls man "nur mal schauen will" was der Button "isVirtual" denn bedeutet... und dann merkt, dass die eingegebene Adresse weg ist.