### PR TITLE
Feat/editableby is set when creating

### DIFF
--- a/src/resources/attractions/repositories/AttractionsRepository.ts
+++ b/src/resources/attractions/repositories/AttractionsRepository.ts
@@ -7,6 +7,7 @@ import { Filter } from "../../../generated/models/Filter.generated";
 import { Reference } from "../../../generated/models/Reference.generated";
 import { RemoveExternalLinkRequest } from "../../../generated/models/RemoveExternalLinkRequest.generated";
 import { UpdateAttractionRequest } from "../../../generated/models/UpdateAttractionRequest.generated";
+import { AuthUser } from "../../../generated/models/AuthUser.generated";
 
 const log: debug.IDebugger = debug("app:attractions-repository");
 
@@ -21,7 +22,7 @@ export interface AttractionsRepository {
 
 	countAttractions(filter?: Filter): Promise<number>;
 
-	addAttraction(createAttraction: CreateAttractionRequest): Promise<Reference | null>;
+	addAttraction(createAttraction: CreateAttractionRequest, creator?: AuthUser): Promise<Reference | null>;
 
 	getAttractionByIdentifier(attractionId: string): Promise<Attraction | null>;
 

--- a/src/resources/attractions/repositories/MongoDBAttractionsRepository.ts
+++ b/src/resources/attractions/repositories/MongoDBAttractionsRepository.ts
@@ -13,6 +13,7 @@ import { generateAttractionID } from "../../../utils/IDUtil";
 import { createMetadata, getUpdatedMetadata } from "../../../utils/MetadataUtil";
 import { generateAttractionReference, getAttractionReferenceProjection } from "../../../utils/ReferenceUtil";
 import { AttractionsRepository } from "./AttractionsRepository";
+import { AuthUser } from "../../../generated/models/AuthUser.generated";
 
 @Service()
 export class MongoDBAttractionsRepository implements AttractionsRepository {
@@ -45,13 +46,13 @@ export class MongoDBAttractionsRepository implements AttractionsRepository {
 		return this.get(filter, getAttractionReferenceProjection(), pagination);
 	}
 
-	async addAttraction(createAttraction: CreateAttractionRequest): Promise<Reference | null> {
+	async addAttraction(createAttraction: CreateAttractionRequest, creator?: AuthUser): Promise<Reference | null> {
 		const newAttraction: Attraction = {
 			...createAttraction,
 			type: "type.Attraction",
 			identifier: generateAttractionID(),
 			status: "attraction.published",
-			metadata: createMetadata(createAttraction.metadata),
+			metadata: createMetadata(creator, createAttraction.metadata),
 		};
 		const attractions = await this.dbConnector.attractions();
 		const result = await attractions.insertOne(newAttraction);

--- a/src/resources/attractions/services/AttractionsService.ts
+++ b/src/resources/attractions/services/AttractionsService.ts
@@ -65,7 +65,7 @@ export class AttractionsService {
 				referenceId: authUser.organizationIdentifier,
 			};
 		}
-		return this.attractionsRepository.addAttraction(createAttractionRequest);
+		return this.attractionsRepository.addAttraction(createAttractionRequest, authUser);
 	}
 
 	async readById(attractionId: any): Promise<Attraction | null> {

--- a/src/resources/events/repositories/EventsRepository.ts
+++ b/src/resources/events/repositories/EventsRepository.ts
@@ -6,6 +6,7 @@ import { Filter } from "../../../generated/models/Filter.generated";
 import { Reference } from "../../../generated/models/Reference.generated";
 import { RescheduleEventRequest } from "../../../generated/models/RescheduleEventRequest.generated";
 import { UpdateEventRequest } from "../../../generated/models/UpdateEventRequest.generated";
+import { AuthUser } from "../../../generated/models/AuthUser.generated";
 
 const log: debug.IDebugger = debug("app:events-repository");
 
@@ -24,7 +25,7 @@ export interface EventsRepository {
 
 	searchDuplicates(event: Event): Promise<Event[]>;
 
-	addEvent(createEvent: CreateEventRequest): Promise<Reference | null>;
+	addEvent(createEvent: CreateEventRequest, creator?: AuthUser): Promise<Reference | null>;
 
 	getEventByIdentifier(eventId: string): Promise<Event | null>;
 

--- a/src/resources/events/repositories/MongoDBEventsRepository.ts
+++ b/src/resources/events/repositories/MongoDBEventsRepository.ts
@@ -13,6 +13,7 @@ import { generateEventID } from "../../../utils/IDUtil";
 import { createMetadata, getUpdatedMetadata } from "../../../utils/MetadataUtil";
 import { generateEventReference, getEventReferenceProjection } from "../../../utils/ReferenceUtil";
 import { EventsRepository } from "./EventsRepository";
+import { AuthUser } from "../../../generated/models/AuthUser.generated";
 
 @Service()
 export class MongoDBEventsRepository implements EventsRepository {
@@ -54,14 +55,14 @@ export class MongoDBEventsRepository implements EventsRepository {
 		return this.get(filter, getEventReferenceProjection(), pagination) as unknown as Promise<Reference[]>;
 	}
 
-	async addEvent(createEvent: CreateEventRequest): Promise<Reference | null> {
+	async addEvent(createEvent: CreateEventRequest, creator?: AuthUser): Promise<Reference | null> {
 		const newEvent: Event = {
 			...createEvent,
 			type: "type.Event",
 			identifier: generateEventID(),
 			status: "event.published",
 			scheduleStatus: "event.scheduled",
-			metadata: createMetadata(createEvent.metadata),
+			metadata: createMetadata(creator, createEvent.metadata),
 		};
 		const events = await this.dbConnector.events();
 		const result = await events.insertOne(newEvent);

--- a/src/resources/events/services/EventsService.ts
+++ b/src/resources/events/services/EventsService.ts
@@ -98,7 +98,7 @@ export class EventsService {
 		if (authUser?.organizationIdentifier) {
 			resource.organizer = { referenceType: "type.Organization", referenceId: authUser.organizationIdentifier };
 		}
-		return this.eventsRepository.addEvent(resource);
+		return this.eventsRepository.addEvent(resource, authUser);
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/resources/locations/repositories/LocationsRepository.ts
+++ b/src/resources/locations/repositories/LocationsRepository.ts
@@ -5,6 +5,7 @@ import { Filter } from "../../../generated/models/Filter.generated";
 import { Location } from "../../../generated/models/Location.generated";
 import { Reference } from "../../../generated/models/Reference.generated";
 import { UpdateLocationRequest } from "../../../generated/models/UpdateLocationRequest.generated";
+import { AuthUser } from "../../../generated/models/AuthUser.generated";
 
 const log: debug.IDebugger = debug("app:locations-repository");
 
@@ -27,7 +28,7 @@ export interface LocationsRepository {
 
 	setLocationManager(identifier: string, reference: Reference): Promise<boolean>;
 
-	addLocation(createLocation: CreateLocationRequest): Promise<Reference | null>;
+	addLocation(createLocation: CreateLocationRequest, creator?: AuthUser): Promise<Reference | null>;
 
 	getLocationByIdentifier(locationId: string): Promise<Location | null>;
 

--- a/src/resources/locations/repositories/MongoDBLocationsRepository.ts
+++ b/src/resources/locations/repositories/MongoDBLocationsRepository.ts
@@ -11,6 +11,7 @@ import { generateLocationID } from "../../../utils/IDUtil";
 import { createMetadata, getUpdatedMetadata } from "../../../utils/MetadataUtil";
 import { generateLocationReference, getLocationReferenceProjection } from "../../../utils/ReferenceUtil";
 import { LocationsRepository } from "./LocationsRepository";
+import { AuthUser } from "../../../generated/models/AuthUser.generated";
 
 @Service()
 export class MongoDBLocationsRepository implements LocationsRepository {
@@ -39,7 +40,7 @@ export class MongoDBLocationsRepository implements LocationsRepository {
 		return this.get(filter, getLocationReferenceProjection(), pagination);
 	}
 
-	async addLocation(createLocation: CreateLocationRequest): Promise<Reference | null> {
+	async addLocation(createLocation: CreateLocationRequest, creator?: AuthUser): Promise<Reference | null> {
 		const locations = await this.dbConnector.locations();
 		const newLocation: Location = {
 			...createLocation,
@@ -47,7 +48,7 @@ export class MongoDBLocationsRepository implements LocationsRepository {
 			identifier: generateLocationID(),
 			status: "location.published",
 			openingStatus: "location.opened",
-			metadata: createMetadata(createLocation.metadata),
+			metadata: createMetadata(creator, createLocation.metadata),
 		};
 		const result = await locations.insertOne(newLocation);
 		if (!result.acknowledged) {

--- a/src/resources/locations/services/LocationsService.ts
+++ b/src/resources/locations/services/LocationsService.ts
@@ -29,7 +29,7 @@ export class LocationsService {
 		if (authUser?.organizationIdentifier) {
 			resource.manager = { referenceType: "type.Organization", referenceId: authUser.organizationIdentifier };
 		}
-		return this.locationsRepository.addLocation(resource);
+		return this.locationsRepository.addLocation(resource, authUser);
 	}
 
 	search(filter: Filter, pagination?: Pagination): Promise<Location[]> {

--- a/src/resources/organizations/OrganizationsRoutes.ts
+++ b/src/resources/organizations/OrganizationsRoutes.ts
@@ -10,6 +10,7 @@ import { UpdateOrganizationRequest } from "../../generated/models/UpdateOrganiza
 import { getPagination } from "../../utils/RequestUtil";
 import { Permit } from "../auth/middleware/Permit";
 import { OrganizationsController } from "./controllers/OrganizationsController";
+import { AuthUser } from "../../generated/models/AuthUser.generated";
 
 @Service()
 export class OrganizationsRoutes {
@@ -34,9 +35,11 @@ export class OrganizationsRoutes {
 			.post(
 				OrganizationsRoutes.basePath + "/",
 				passport.authenticate("authenticated-user", { session: false }),
+				Permit.authorizesForAction(),
 				(req: express.Request, res: express.Response) => {
 					const createOrganizationRequest = req.body as CreateOrganizationRequest;
-					this.organizationsController.createOrganization(res, createOrganizationRequest);
+					const authUser = req.user as AuthUser;
+					this.organizationsController.createOrganization(res, createOrganizationRequest, authUser);
 				},
 			);
 
@@ -46,8 +49,8 @@ export class OrganizationsRoutes {
 			Permit.authorizesForAction(),
 			(req: express.Request, res: express.Response) => {
 				const createOrganizationsRequest = req.body as CreateOrganizationRequest[];
-
-				this.organizationsController.createOrganizations(res, createOrganizationsRequest);
+				const authUser = req.user as AuthUser;
+				this.organizationsController.createOrganizations(res, createOrganizationsRequest, authUser);
 			},
 		);
 

--- a/src/resources/organizations/controllers/OrganizationsController.ts
+++ b/src/resources/organizations/controllers/OrganizationsController.ts
@@ -21,6 +21,7 @@ import { generateOrganizationMembership } from "../../../utils/MembershipUtil";
 import { GetOrganizationMembershipsResponse } from "../../../generated/models/GetOrganizationMembershipsResponse.generated";
 import { UpdateOrganizationMembershipRequest } from "../../../generated/models/UpdateOrganizationMembershipRequest.generated";
 import { GetOrganizationMembershipResponse } from "../../../generated/models/GetOrganizationMembershipResponse.generated";
+import { AuthUser } from "../../../generated/models/AuthUser.generated";
 
 const log: debug.IDebugger = debug("app:organizations-controller");
 
@@ -122,8 +123,8 @@ export class OrganizationsController implements ResourcePermissionController {
 		}
 	}
 
-	async createOrganization(res: express.Response, createOrganization: CreateOrganizationRequest) {
-		const organizationReference = await this.organizationsService.create(createOrganization);
+	async createOrganization(res: express.Response, createOrganization: CreateOrganizationRequest, authUser?: AuthUser) {
+		const organizationReference = await this.organizationsService.create(createOrganization, authUser);
 		if (organizationReference) {
 			res
 				.status(201)
@@ -141,10 +142,14 @@ export class OrganizationsController implements ResourcePermissionController {
 		}
 	}
 
-	async createOrganizations(res: express.Response, createOrganizationsRequest: CreateOrganizationRequest[]) {
+	async createOrganizations(
+		res: express.Response,
+		createOrganizationsRequest: CreateOrganizationRequest[],
+		authUser?: AuthUser,
+	) {
 		const organizationsReferences: Promise<Reference | null>[] = [];
 		createOrganizationsRequest.forEach(async (request) => {
-			organizationsReferences.push(this.organizationsService.create(request));
+			organizationsReferences.push(this.organizationsService.create(request, authUser));
 		});
 		const oR = await Promise.all(organizationsReferences);
 

--- a/src/resources/organizations/repositories/MongoDBOrganizationsRepository.ts
+++ b/src/resources/organizations/repositories/MongoDBOrganizationsRepository.ts
@@ -58,13 +58,14 @@ export class MongoDBOrganizationsRepository implements OrganizationsRepository {
 	}
 
 	async addOrganization(createOrganization: CreateOrganizationRequest): Promise<Reference | null> {
+		const id = generateOrganizationID();
 		const newOrganization: Organization = {
 			...createOrganization,
 			type: "type.Organization",
-			identifier: generateOrganizationID(),
+			identifier: id,
 			status: "organization.published",
 			activationStatus: "organization.active",
-			metadata: createMetadata(createOrganization.metadata),
+			metadata: createMetadata({ organizationIdentifier: id }, createOrganization.metadata),
 		};
 		const organizations = await this.dbConnector.organizations();
 		const result = await organizations.insertOne(newOrganization);

--- a/src/resources/organizations/repositories/MongoDBOrganizationsRepository.ts
+++ b/src/resources/organizations/repositories/MongoDBOrganizationsRepository.ts
@@ -11,6 +11,7 @@ import { generateOrganizationID } from "../../../utils/IDUtil";
 import { createMetadata, getUpdatedMetadata } from "../../../utils/MetadataUtil";
 import { getOrganizationReferenceProjection } from "../../../utils/ReferenceUtil";
 import { OrganizationsRepository } from "./OrganizationsRepository";
+import { AuthUser } from "../../../generated/models/AuthUser.generated";
 
 @Service()
 export class MongoDBOrganizationsRepository implements OrganizationsRepository {
@@ -57,15 +58,14 @@ export class MongoDBOrganizationsRepository implements OrganizationsRepository {
 		);
 	}
 
-	async addOrganization(createOrganization: CreateOrganizationRequest): Promise<Reference | null> {
-		const id = generateOrganizationID();
+	async addOrganization(createOrganization: CreateOrganizationRequest, creator?: AuthUser): Promise<Reference | null> {
 		const newOrganization: Organization = {
 			...createOrganization,
 			type: "type.Organization",
-			identifier: id,
+			identifier: generateOrganizationID(),
 			status: "organization.published",
 			activationStatus: "organization.active",
-			metadata: createMetadata({ organizationIdentifier: id }, createOrganization.metadata),
+			metadata: createMetadata(creator, createOrganization.metadata),
 		};
 		const organizations = await this.dbConnector.organizations();
 		const result = await organizations.insertOne(newOrganization);

--- a/src/resources/organizations/repositories/OrganizationsRepository.ts
+++ b/src/resources/organizations/repositories/OrganizationsRepository.ts
@@ -5,6 +5,7 @@ import { Filter } from "../../../generated/models/Filter.generated";
 import { Organization } from "../../../generated/models/Organization.generated";
 import { Reference } from "../../../generated/models/Reference.generated";
 import { UpdateOrganizationRequest } from "../../../generated/models/UpdateOrganizationRequest.generated";
+import { AuthUser } from "../../../generated/models/AuthUser.generated";
 
 const log: debug.IDebugger = debug("app:organizations-repository");
 
@@ -23,7 +24,7 @@ export interface OrganizationsRepository {
 
 	getOrganizationReferenceByIdentifier(identifier: string): Promise<Reference | null>;
 
-	addOrganization(createOrganization: CreateOrganizationRequest): Promise<Reference | null>;
+	addOrganization(createOrganization: CreateOrganizationRequest, creator?: AuthUser): Promise<Reference | null>;
 
 	updateOrganizationById(organizationId: string, organizationFields: UpdateOrganizationRequest): Promise<boolean>;
 

--- a/src/resources/organizations/services/OrganizationsService.ts
+++ b/src/resources/organizations/services/OrganizationsService.ts
@@ -6,6 +6,7 @@ import { Organization } from "../../../generated/models/Organization.generated";
 import { Reference } from "../../../generated/models/Reference.generated";
 import { UpdateOrganizationRequest } from "../../../generated/models/UpdateOrganizationRequest.generated";
 import { OrganizationsRepository } from "../repositories/OrganizationsRepository";
+import { AuthUser } from "../../../generated/models/AuthUser.generated";
 
 @Service()
 export class OrganizationsService {
@@ -23,8 +24,8 @@ export class OrganizationsService {
 		return this.organizationsRepository.searchOrganizations(filter, pagination);
 	}
 
-	async create(resource: CreateOrganizationRequest): Promise<Reference | null> {
-		return await this.organizationsRepository.addOrganization(resource);
+	async create(resource: CreateOrganizationRequest, authUser?: AuthUser): Promise<Reference | null> {
+		return await this.organizationsRepository.addOrganization(resource, authUser);
 	}
 
 	async readById(id: string): Promise<Organization | null> {

--- a/src/schemas/kulturdaten.berlin.openapi.generated.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.generated.yml
@@ -1838,6 +1838,11 @@ components:
               type: object
               additionalProperties:
                 type: string
+            editableBy:
+              type: array
+              description: List of organizations that can edit this object.
+              items:
+                type: string
           required:
             - created
             - updated
@@ -2104,6 +2109,11 @@ components:
                   type: object
                   additionalProperties:
                     type: string
+                editableBy:
+                  type: array
+                  description: List of organizations that can edit this object.
+                  items:
+                    type: string
               required:
                 - created
                 - updated
@@ -2246,6 +2256,11 @@ components:
                       externalIDs:
                         type: object
                         additionalProperties:
+                          type: string
+                      editableBy:
+                        type: array
+                        description: List of organizations that can edit this object.
+                        items:
                           type: string
                     required:
                       - created
@@ -2513,6 +2528,11 @@ components:
               type: object
               additionalProperties:
                 type: string
+            editableBy:
+              type: array
+              description: List of organizations that can edit this object.
+              items:
+                type: string
           required:
             - created
             - updated
@@ -2648,6 +2668,11 @@ components:
             externalIDs:
               type: object
               additionalProperties:
+                type: string
+            editableBy:
+              type: array
+              description: List of organizations that can edit this object.
+              items:
                 type: string
           required:
             - created
@@ -2908,6 +2933,11 @@ components:
             externalIDs:
               type: object
               additionalProperties:
+                type: string
+            editableBy:
+              type: array
+              description: List of organizations that can edit this object.
+              items:
                 type: string
           required:
             - created
@@ -3184,6 +3214,11 @@ components:
                       type: object
                       additionalProperties:
                         type: string
+                    editableBy:
+                      type: array
+                      description: List of organizations that can edit this object.
+                      items:
+                        type: string
                   required:
                     - created
                     - updated
@@ -3417,6 +3452,11 @@ components:
                           externalIDs:
                             type: object
                             additionalProperties:
+                              type: string
+                          editableBy:
+                            type: array
+                            description: List of organizations that can edit this object.
+                            items:
                               type: string
                         required:
                           - created
@@ -3815,6 +3855,11 @@ components:
                           externalIDs:
                             type: object
                             additionalProperties:
+                              type: string
+                          editableBy:
+                            type: array
+                            description: List of organizations that can edit this object.
+                            items:
                               type: string
                         required:
                           - created
@@ -4217,6 +4262,11 @@ components:
                             type: object
                             additionalProperties:
                               type: string
+                          editableBy:
+                            type: array
+                            description: List of organizations that can edit this object.
+                            items:
+                              type: string
                         required:
                           - created
                           - updated
@@ -4557,6 +4607,11 @@ components:
                             type: object
                             additionalProperties:
                               type: string
+                          editableBy:
+                            type: array
+                            description: List of organizations that can edit this object.
+                            items:
+                              type: string
                         required:
                           - created
                           - updated
@@ -4734,6 +4789,11 @@ components:
                     externalIDs:
                       type: object
                       additionalProperties:
+                        type: string
+                    editableBy:
+                      type: array
+                      description: List of organizations that can edit this object.
+                      items:
                         type: string
                   required:
                     - created
@@ -4997,6 +5057,11 @@ components:
                           externalIDs:
                             type: object
                             additionalProperties:
+                              type: string
+                          editableBy:
+                            type: array
+                            description: List of organizations that can edit this object.
+                            items:
                               type: string
                         required:
                           - created
@@ -5575,6 +5640,11 @@ components:
                             type: object
                             additionalProperties:
                               type: string
+                          editableBy:
+                            type: array
+                            description: List of organizations that can edit this object.
+                            items:
+                              type: string
                         required:
                           - created
                           - updated
@@ -5878,6 +5948,11 @@ components:
                     externalIDs:
                       type: object
                       additionalProperties:
+                        type: string
+                    editableBy:
+                      type: array
+                      description: List of organizations that can edit this object.
+                      items:
                         type: string
                   required:
                     - created
@@ -6382,6 +6457,11 @@ components:
                           externalIDs:
                             type: object
                             additionalProperties:
+                              type: string
+                          editableBy:
+                            type: array
+                            description: List of organizations that can edit this object.
+                            items:
                               type: string
                         required:
                           - created
@@ -7009,6 +7089,11 @@ components:
                             type: object
                             additionalProperties:
                               type: string
+                          editableBy:
+                            type: array
+                            description: List of organizations that can edit this object.
+                            items:
+                              type: string
                         required:
                           - created
                           - updated
@@ -7319,6 +7404,11 @@ components:
                     externalIDs:
                       type: object
                       additionalProperties:
+                        type: string
+                    editableBy:
+                      type: array
+                      description: List of organizations that can edit this object.
+                      items:
                         type: string
                   required:
                     - created
@@ -7924,6 +8014,11 @@ components:
                         type: object
                         additionalProperties:
                           type: string
+                      editableBy:
+                        type: array
+                        description: List of organizations that can edit this object.
+                        items:
+                          type: string
                     required:
                       - created
                       - updated
@@ -8354,6 +8449,11 @@ components:
                         type: object
                         additionalProperties:
                           type: string
+                      editableBy:
+                        type: array
+                        description: List of organizations that can edit this object.
+                        items:
+                          type: string
                     required:
                       - created
                       - updated
@@ -8431,6 +8531,11 @@ components:
                     externalIDs:
                       type: object
                       additionalProperties:
+                        type: string
+                    editableBy:
+                      type: array
+                      description: List of organizations that can edit this object.
+                      items:
                         type: string
                   required:
                     - created
@@ -8532,6 +8637,11 @@ components:
                       type: object
                       additionalProperties:
                         type: string
+                    editableBy:
+                      type: array
+                      description: List of organizations that can edit this object.
+                      items:
+                        type: string
                   required:
                     - created
                     - updated
@@ -8602,6 +8712,11 @@ components:
                         externalIDs:
                           type: object
                           additionalProperties:
+                            type: string
+                        editableBy:
+                          type: array
+                          description: List of organizations that can edit this object.
+                          items:
                             type: string
                       required:
                         - created
@@ -8749,6 +8864,13 @@ components:
                               externalIDs:
                                 type: object
                                 additionalProperties:
+                                  type: string
+                              editableBy:
+                                type: array
+                                description: >-
+                                  List of organizations that can edit this
+                                  object.
+                                items:
                                   type: string
                             required:
                               - created
@@ -9073,6 +9195,13 @@ components:
                                 type: object
                                 additionalProperties:
                                   type: string
+                              editableBy:
+                                type: array
+                                description: >-
+                                  List of organizations that can edit this
+                                  object.
+                                items:
+                                  type: string
                             required:
                               - created
                               - updated
@@ -9225,6 +9354,13 @@ components:
                                     externalIDs:
                                       type: object
                                       additionalProperties:
+                                        type: string
+                                    editableBy:
+                                      type: array
+                                      description: >-
+                                        List of organizations that can edit this
+                                        object.
+                                      items:
                                         type: string
                                   required:
                                     - created

--- a/src/schemas/models/Metadata.yml
+++ b/src/schemas/models/Metadata.yml
@@ -25,6 +25,11 @@ properties:
     type: object
     additionalProperties:
       type: string
+  editableBy:
+    type: array
+    description: List of organizations that can edit this object.
+    items:
+      type: string
 required:
   - created
   - updated

--- a/src/utils/MetadataUtil.ts
+++ b/src/utils/MetadataUtil.ts
@@ -16,11 +16,20 @@ export function getUpdatedMetadata() {
 /**
  * Creates a valid metadata object with timestamps for new and upated entities.
  */
-export function createMetadata(existingMetadata?: Partial<Metadata>): Metadata {
+export function createMetadata(creator?: Creator, existingMetadata?: Partial<Metadata>): Metadata {
 	const currentTimestamp = getCurrentTimestamp();
+	const editableBy = [];
+	if (creator?.organizationIdentifier) {
+		editableBy.push(creator.organizationIdentifier);
+	}
 	return {
 		...existingMetadata,
 		created: existingMetadata?.created || currentTimestamp,
 		updated: currentTimestamp,
+		editableBy: editableBy,
 	};
+}
+
+export interface Creator {
+	organizationIdentifier?: string;
 }


### PR DESCRIPTION
Ich habe hier mit "Creator" gearbeitet, da wir sicher bald solche Dinge wie "createdBy" oder "editedBy" usw. haben wollen. Daher wird bis ins Repo rein der AuthUser mit diesen Daten übergeben.

Bei der Organization wird jetzt erstmal davon ausgegangen, dass wir die "erstellenden" Organizations am Anfang anlegen (Bezirke) und alle weiteren Organizations von eben diesen angelegt und bearbeitet werden können. (Zukunfsmusik)