### PR TITLE
Feat/editable by filter

### DIFF
--- a/src/common/parameters/Params.ts
+++ b/src/common/parameters/Params.ts
@@ -1,0 +1,3 @@
+export type Params = {
+	[key: string]: string;
+};

--- a/src/resources/attractions/AttractionsRoutes.ts
+++ b/src/resources/attractions/AttractionsRoutes.ts
@@ -12,6 +12,7 @@ import { getPagination } from "../../utils/RequestUtil";
 import { AttractionsController } from "./controllers/AttractionsController";
 import { Permit } from "../auth/middleware/Permit";
 import { AuthUser } from "../../generated/models/AuthUser.generated";
+import { Params } from "../../common/parameters/Params";
 
 const log: debug.IDebugger = debug("app:attractions-routes");
 
@@ -26,15 +27,14 @@ export class AttractionsRoutes {
 
 		router
 			.get(AttractionsRoutes.basePath + "/", (req: express.Request, res: express.Response) => {
-				const asReference = req.query.asReference;
 				const pagination: Pagination = getPagination(req);
-				const curatedBy = req.query.curatedBy as string;
+				const params: Params = {
+					asReference: req.query.asReference as string,
+					curatedBy: req.query.curatedBy as string,
+					editableBy: req.query.editableBy as string,
+				};
 
-				if (asReference) {
-					this.attractionsController.listAttractionsAsReference(res, pagination, curatedBy);
-				} else {
-					this.attractionsController.listAttractions(res, pagination, curatedBy);
-				}
+				this.attractionsController.listAttractions(res, pagination, params);
 			})
 			.post(
 				AttractionsRoutes.basePath + "/",

--- a/src/resources/attractions/controllers/AttractionsController.ts
+++ b/src/resources/attractions/controllers/AttractionsController.ts
@@ -20,6 +20,7 @@ import { Filter } from "../../../generated/models/Filter.generated";
 import { AuthUser } from "../../../generated/models/AuthUser.generated";
 import { Params } from "../../../common/parameters/Params";
 import { Attraction } from "../../../generated/models/Attraction.generated";
+import { getEditableByFilter } from "../../../utils/MetadataUtil";
 
 @Service()
 export class AttractionsController implements ResourcePermissionController {
@@ -248,24 +249,14 @@ export class AttractionsController implements ResourcePermissionController {
 		}
 	}
 
-	getCuratedByFilter(curatedBy?: string) {
+	private getCuratedByFilter(curatedBy?: string) {
 		return curatedBy ? { "curator.referenceId": curatedBy } : {};
 	}
 
-	getEditableByFilter(editableBy?: string) {
-		return editableBy
-			? {
-					"metadata.editableBy": {
-						$in: [editableBy],
-					},
-			  }
-			: {};
-	}
-
-	getAttractionsFilter(params?: Params): Filter {
+	private getAttractionsFilter(params?: Params): Filter {
 		const filter: Filter = {
 			...this.getCuratedByFilter(params?.curatedBy),
-			...this.getEditableByFilter(params?.editableBy),
+			...getEditableByFilter(params?.editableBy),
 		};
 
 		return filter;

--- a/src/resources/attractions/controllers/AttractionsController.ts
+++ b/src/resources/attractions/controllers/AttractionsController.ts
@@ -18,47 +18,37 @@ import { AttractionsService } from "../services/AttractionsService";
 import { ResourcePermissionController } from "../../auth/controllers/ResourcePermissionController";
 import { Filter } from "../../../generated/models/Filter.generated";
 import { AuthUser } from "../../../generated/models/AuthUser.generated";
+import { Params } from "../../../common/parameters/Params";
+import { Attraction } from "../../../generated/models/Attraction.generated";
 
 @Service()
 export class AttractionsController implements ResourcePermissionController {
 	constructor(public attractionsService: AttractionsService) {}
 
-	getCuratedByFilter(curatedBy?: string) {
-		return curatedBy ? { "curator.referenceId": curatedBy } : undefined;
-	}
+	async listAttractions(res: Response, pagination: Pagination, params?: Params) {
+		const filter: Filter = this.getAttractionsFilter(params);
+		const totalCount = await this.attractionsService.countAttractions(filter);
 
-	async listAttractions(res: Response, pagination: Pagination, curatedBy?: string) {
-		const attractions = await this.attractionsService.list(pagination, this.getCuratedByFilter(curatedBy));
-		const totalCount = await this.attractionsService.countAttractions(this.getCuratedByFilter(curatedBy));
-		res.status(200).send(
-			new SuccessResponseBuilder<GetAttractionsResponse>()
-				.okResponse({
-					page: pagination.page,
-					pageSize: pagination.pageSize,
-					totalCount: totalCount,
-					attractions: attractions,
-				})
-				.build(),
-		);
-	}
+		const sendAttractionsResponse = (data: { attractions?: Attraction[]; attractionsReferences?: Reference[] }) => {
+			res.status(200).send(
+				new SuccessResponseBuilder<GetAttractionsResponse>()
+					.okResponse({
+						page: pagination.page,
+						pageSize: pagination.pageSize,
+						totalCount: totalCount,
+						...data,
+					})
+					.build(),
+			);
+		};
 
-	async listAttractionsAsReference(res: Response, pagination: Pagination, curatedBy?: string) {
-		const attractionsReferences = await this.attractionsService.listAsReferences(
-			pagination,
-			this.getCuratedByFilter(curatedBy),
-		);
-		const totalCount = await this.attractionsService.countAttractions(this.getCuratedByFilter(curatedBy));
-
-		res.status(200).send(
-			new SuccessResponseBuilder<GetAttractionsResponse>()
-				.okResponse({
-					page: pagination.page,
-					pageSize: pagination.pageSize,
-					totalCount: totalCount,
-					attractionsReferences: attractionsReferences,
-				})
-				.build(),
-		);
+		if (params?.asReference) {
+			const attractionsReferences = await this.attractionsService.listAsReferences(pagination, filter);
+			sendAttractionsResponse({ attractionsReferences });
+		} else {
+			const attractions = await this.attractionsService.list(pagination, filter);
+			sendAttractionsResponse({ attractions });
+		}
 	}
 
 	async listAttractionsForAdmins(res: Response, pagination: Pagination) {
@@ -256,5 +246,28 @@ export class AttractionsController implements ResourcePermissionController {
 		} else {
 			res.status(400).send(new ErrorResponseBuilder().badRequestResponse("Failed to unpublish the attraction").build());
 		}
+	}
+
+	getCuratedByFilter(curatedBy?: string) {
+		return curatedBy ? { "curator.referenceId": curatedBy } : {};
+	}
+
+	getEditableByFilter(editableBy?: string) {
+		return editableBy
+			? {
+					"metadata.editableBy": {
+						$in: [editableBy],
+					},
+			  }
+			: {};
+	}
+
+	getAttractionsFilter(params?: Params): Filter {
+		const filter: Filter = {
+			...this.getCuratedByFilter(params?.curatedBy),
+			...this.getEditableByFilter(params?.editableBy),
+		};
+
+		return filter;
 	}
 }

--- a/src/resources/events/EventsRoutes.ts
+++ b/src/resources/events/EventsRoutes.ts
@@ -16,6 +16,7 @@ import { EventsController } from "./controllers/EventsController";
 import { Permit } from "../auth/middleware/Permit";
 import { AuthUser } from "../../generated/models/AuthUser.generated";
 import { CreateEventRequest } from "../../generated/models/CreateEventRequest.generated";
+import { Params } from "../../common/parameters/Params";
 
 const log: debug.IDebugger = debug("app:events-routes");
 
@@ -30,15 +31,16 @@ export class EventsRoutes {
 
 		router
 			.get(EventsRoutes.basePath + "/", (req: express.Request, res: express.Response) => {
-				const asReference = req.query.asReference;
 				const pagination: Pagination = getPagination(req);
-				const organizedBy = req.query.organizedBy as string;
+				const params: Params = {
+					asReference: req.query.asReference as string,
+					organizedBy: req.query.organizedBy as string,
+					editableBy: req.query.editableBy as string,
+					byLocation: req.query.byLocation as string,
+					byAttraction: req.query.byAttraction as string,
+				};
 
-				if (asReference) {
-					this.eventsController.listEventsAsReference(res, pagination, organizedBy);
-				} else {
-					this.eventsController.listEvents(res, pagination, organizedBy);
-				}
+				this.eventsController.listEvents(res, pagination, params);
 			})
 			.post(
 				EventsRoutes.basePath + "/",

--- a/src/resources/events/controllers/EventsController.ts
+++ b/src/resources/events/controllers/EventsController.ts
@@ -24,6 +24,7 @@ import { Params } from "../../../common/parameters/Params";
 import { GetEventsResponse } from "../../../generated/models/GetEventsResponse.generated";
 import { Reference } from "../../../generated/models/Reference.generated";
 import { Event } from "../../../generated/models/Event.generated";
+import { getEditableByFilter } from "../../../utils/MetadataUtil";
 
 const log: debug.IDebugger = debug("app:events-controller");
 
@@ -312,21 +313,11 @@ export class EventsController implements ResourcePermissionController {
 		}
 	}
 
-	getOrganizedByFilter(organizedBy?: string) {
+	private getOrganizedByFilter(organizedBy?: string) {
 		return organizedBy ? { "organizer.referenceId": organizedBy } : {};
 	}
 
-	getEditableByFilter(editableBy?: string) {
-		return editableBy
-			? {
-					"metadata.editableBy": {
-						$in: [editableBy],
-					},
-			  }
-			: {};
-	}
-
-	getByLocationFilter(byLocation?: string) {
+	private getByLocationFilter(byLocation?: string) {
 		return byLocation
 			? {
 					"locations.referenceId": byLocation,
@@ -334,7 +325,7 @@ export class EventsController implements ResourcePermissionController {
 			: {};
 	}
 
-	getByAttractionFilter(byAttraction?: string) {
+	private getByAttractionFilter(byAttraction?: string) {
 		return byAttraction
 			? {
 					"attractions.referenceId": byAttraction,
@@ -342,10 +333,10 @@ export class EventsController implements ResourcePermissionController {
 			: {};
 	}
 
-	getEventsFilter(params?: Params): Filter {
+	private getEventsFilter(params?: Params): Filter {
 		const filter: Filter = {
 			...this.getOrganizedByFilter(params?.organizedBy),
-			...this.getEditableByFilter(params?.editableBy),
+			...getEditableByFilter(params?.editableBy),
 			...this.getByLocationFilter(params?.byLocation),
 			...this.getByAttractionFilter(params?.byAttraction),
 		};

--- a/src/resources/events/controllers/EventsController.ts
+++ b/src/resources/events/controllers/EventsController.ts
@@ -13,7 +13,6 @@ import { SearchEventsResponse } from "../../../generated/models/SearchEventsResp
 import { SetEventOrganizerRequest } from "../../../generated/models/SetEventOrganizerRequest.generated";
 import { UpdateEventRequest } from "../../../generated/models/UpdateEventRequest.generated";
 import { EventsService } from "../services/EventsService";
-import { GetEventsResponse } from "../../../generated/models/GetEventsResponse.generated";
 import { CreateEventResponse } from "../../../generated/models/CreateEventResponse.generated";
 import { DuplicateEventResponse } from "../../../generated/models/DuplicateEventResponse.generated";
 import { GetEventResponse } from "../../../generated/models/GetEventResponse.generated";
@@ -21,6 +20,10 @@ import { ResourcePermissionController } from "../../auth/controllers/ResourcePer
 import { Filter } from "../../../generated/models/Filter.generated";
 import { CreateEventRequest } from "../../../generated/models/CreateEventRequest.generated";
 import { AuthUser } from "../../../generated/models/AuthUser.generated";
+import { Params } from "../../../common/parameters/Params";
+import { GetEventsResponse } from "../../../generated/models/GetEventsResponse.generated";
+import { Reference } from "../../../generated/models/Reference.generated";
+import { Event } from "../../../generated/models/Event.generated";
 
 const log: debug.IDebugger = debug("app:events-controller");
 
@@ -29,22 +32,70 @@ export class EventsController implements ResourcePermissionController {
 	constructor(public eventsService: EventsService) {}
 
 	getOrganizedByFilter(organizedBy?: string) {
-		return organizedBy ? { "organizer.referenceId": organizedBy } : undefined;
+		return organizedBy ? { "organizer.referenceId": organizedBy } : {};
 	}
 
-	async listEvents(res: express.Response, pagination: Pagination, organizedBy?: string) {
-		const events = await this.eventsService.list(pagination, this.getOrganizedByFilter(organizedBy));
-		const totalCount = await this.eventsService.countEvents(this.getOrganizedByFilter(organizedBy));
-		res.status(200).send(
-			new SuccessResponseBuilder<GetEventsResponse>()
-				.okResponse({
-					page: pagination.page,
-					pageSize: pagination.pageSize,
-					totalCount: totalCount,
-					events: events,
-				})
-				.build(),
-		);
+	getEditableByFilter(editableBy?: string) {
+		return editableBy
+			? {
+					"metadata.editableBy": {
+						$in: [editableBy],
+					},
+			  }
+			: {};
+	}
+
+	getByLocationFilter(byLocation?: string) {
+		return byLocation
+			? {
+					"locations.referenceId": byLocation,
+			  }
+			: {};
+	}
+
+	getByAttractionFilter(byAttraction?: string) {
+		return byAttraction
+			? {
+					"attractions.referenceId": byAttraction,
+			  }
+			: {};
+	}
+
+	getEventsFilter(params?: Params): Filter {
+		const filter: Filter = {
+			...this.getOrganizedByFilter(params?.organizedBy),
+			...this.getEditableByFilter(params?.editableBy),
+			...this.getByLocationFilter(params?.byLocation),
+			...this.getByAttractionFilter(params?.byAttraction),
+		};
+
+		return filter;
+	}
+
+	async listEvents(res: express.Response, pagination: Pagination, params?: Params) {
+		const filter: Filter = this.getEventsFilter(params);
+		const totalCount = await this.eventsService.countEvents(filter);
+
+		const sendEventsResponse = (data: { events?: Event[]; eventsReferences?: Reference[] }) => {
+			res.status(200).send(
+				new SuccessResponseBuilder<GetEventsResponse>()
+					.okResponse({
+						page: pagination.page,
+						pageSize: pagination.pageSize,
+						totalCount: totalCount,
+						...data,
+					})
+					.build(),
+			);
+		};
+
+		if (params?.asReference) {
+			const eventsReferences = await this.eventsService.listAsReferences(pagination, filter);
+			sendEventsResponse({ eventsReferences });
+		} else {
+			const events = await this.eventsService.list(pagination, filter);
+			sendEventsResponse({ events });
+		}
 	}
 
 	async listEventsAsReference(res: express.Response, pagination: Pagination, organizedBy?: string) {

--- a/src/resources/events/controllers/EventsController.ts
+++ b/src/resources/events/controllers/EventsController.ts
@@ -31,47 +31,6 @@ const log: debug.IDebugger = debug("app:events-controller");
 export class EventsController implements ResourcePermissionController {
 	constructor(public eventsService: EventsService) {}
 
-	getOrganizedByFilter(organizedBy?: string) {
-		return organizedBy ? { "organizer.referenceId": organizedBy } : {};
-	}
-
-	getEditableByFilter(editableBy?: string) {
-		return editableBy
-			? {
-					"metadata.editableBy": {
-						$in: [editableBy],
-					},
-			  }
-			: {};
-	}
-
-	getByLocationFilter(byLocation?: string) {
-		return byLocation
-			? {
-					"locations.referenceId": byLocation,
-			  }
-			: {};
-	}
-
-	getByAttractionFilter(byAttraction?: string) {
-		return byAttraction
-			? {
-					"attractions.referenceId": byAttraction,
-			  }
-			: {};
-	}
-
-	getEventsFilter(params?: Params): Filter {
-		const filter: Filter = {
-			...this.getOrganizedByFilter(params?.organizedBy),
-			...this.getEditableByFilter(params?.editableBy),
-			...this.getByLocationFilter(params?.byLocation),
-			...this.getByAttractionFilter(params?.byAttraction),
-		};
-
-		return filter;
-	}
-
 	async listEvents(res: express.Response, pagination: Pagination, params?: Params) {
 		const filter: Filter = this.getEventsFilter(params);
 		const totalCount = await this.eventsService.countEvents(filter);
@@ -351,5 +310,46 @@ export class EventsController implements ResourcePermissionController {
 		} else {
 			res.status(400).send(new ErrorResponseBuilder().badRequestResponse("Failed to reschedule the event").build());
 		}
+	}
+
+	getOrganizedByFilter(organizedBy?: string) {
+		return organizedBy ? { "organizer.referenceId": organizedBy } : {};
+	}
+
+	getEditableByFilter(editableBy?: string) {
+		return editableBy
+			? {
+					"metadata.editableBy": {
+						$in: [editableBy],
+					},
+			  }
+			: {};
+	}
+
+	getByLocationFilter(byLocation?: string) {
+		return byLocation
+			? {
+					"locations.referenceId": byLocation,
+			  }
+			: {};
+	}
+
+	getByAttractionFilter(byAttraction?: string) {
+		return byAttraction
+			? {
+					"attractions.referenceId": byAttraction,
+			  }
+			: {};
+	}
+
+	getEventsFilter(params?: Params): Filter {
+		const filter: Filter = {
+			...this.getOrganizedByFilter(params?.organizedBy),
+			...this.getEditableByFilter(params?.editableBy),
+			...this.getByLocationFilter(params?.byLocation),
+			...this.getByAttractionFilter(params?.byAttraction),
+		};
+
+		return filter;
 	}
 }

--- a/src/resources/locations/LocationsRoutes.ts
+++ b/src/resources/locations/LocationsRoutes.ts
@@ -12,6 +12,7 @@ import { LocationsController } from "./controllers/LocationsController";
 import { Permit } from "../auth/middleware/Permit";
 import { AuthUser } from "../../generated/models/AuthUser.generated";
 import { CreateLocationRequest } from "../../generated/models/CreateLocationRequest.generated";
+import { Params } from "../../common/parameters/Params";
 
 const log: debug.IDebugger = debug("app:locations-routes");
 
@@ -26,15 +27,14 @@ export class LocationsRoutes {
 
 		router
 			.get(LocationsRoutes.basePath + "/", (req: express.Request, res: express.Response) => {
-				const asReference = req.query.asReference;
 				const pagination: Pagination = getPagination(req);
-				const managedBy = req.query.managedBy as string;
+				const params: Params = {
+					asReference: req.query.asReference as string,
+					managedBy: req.query.managedBy as string,
+					editableBy: req.query.editableBy as string,
+				};
 
-				if (asReference) {
-					this.locationsController.listLocationsAsReference(res, pagination, managedBy);
-				} else {
-					this.locationsController.listLocations(res, pagination, managedBy);
-				}
+				this.locationsController.listLocations(res, pagination, params);
 			})
 			.post(
 				LocationsRoutes.basePath + "/",

--- a/src/resources/locations/controllers/LocationsController.ts
+++ b/src/resources/locations/controllers/LocationsController.ts
@@ -5,6 +5,7 @@ import { Pagination } from "../../../common/parameters/Pagination";
 import { ErrorResponseBuilder, SuccessResponseBuilder } from "../../../common/responses/SuccessResponseBuilder";
 import { ClaimLocationRequest } from "../../../generated/models/ClaimLocationRequest.generated";
 import { Reference } from "../../../generated/models/Reference.generated";
+import { Location } from "../../../generated/models/Location.generated";
 import { SearchLocationsRequest } from "../../../generated/models/SearchLocationsRequest.generated";
 import { SearchLocationsResponse } from "../../../generated/models/SearchLocationsResponse.generated";
 import { SetLocationManagerRequest } from "../../../generated/models/SetLocationManagerRequest.generated";
@@ -17,6 +18,7 @@ import { GetLocationResponse } from "../../../generated/models/GetLocationRespon
 import { CreateLocationResponse } from "../../../generated/models/CreateLocationResponse.generated";
 import { AuthUser } from "../../../generated/models/AuthUser.generated";
 import { CreateLocationRequest } from "../../../generated/models/CreateLocationRequest.generated";
+import { Params } from "../../../common/parameters/Params";
 
 const log: debug.IDebugger = debug("app:locations-controller");
 
@@ -24,50 +26,29 @@ const log: debug.IDebugger = debug("app:locations-controller");
 export class LocationsController implements ResourcePermissionController {
 	constructor(public locationsService: LocationsService) {}
 
-	getManagedByFilter(managedBy?: string) {
-		return managedBy ? { "manager.referenceId": managedBy } : undefined;
-	}
+	async listLocations(res: express.Response, pagination: Pagination, params?: Params) {
+		const filter: Filter = this.getLocationsFilter(params);
+		const totalCount = await this.locationsService.countLocations(filter);
 
-	async listLocations(res: express.Response, pagination: Pagination, managedBy?: string) {
-		const locations = await this.locationsService.list(pagination, this.getManagedByFilter(managedBy));
-		const totalCount = await this.locationsService.countLocations(this.getManagedByFilter(managedBy));
-
-		if (locations) {
+		const sendLocationsResponse = (data: { locations?: Location[]; locationsReferences?: Reference[] }) => {
 			res.status(200).send(
 				new SuccessResponseBuilder<GetLocationsResponse>()
 					.okResponse({
 						page: pagination.page,
 						pageSize: pagination.pageSize,
 						totalCount: totalCount,
-						locations: locations,
+						...data,
 					})
 					.build(),
 			);
-		} else {
-			res.status(404).send(new ErrorResponseBuilder().notFoundResponse("Locations not found").build());
-		}
-	}
+		};
 
-	async listLocationsAsReference(res: express.Response, pagination: Pagination, managedBy?: string) {
-		const locationsReferences = await this.locationsService.listAsReferences(
-			pagination,
-			this.getManagedByFilter(managedBy),
-		);
-		const totalCount = await this.locationsService.countLocations(this.getManagedByFilter(managedBy));
-
-		if (locationsReferences) {
-			res.status(200).send(
-				new SuccessResponseBuilder<GetLocationsResponse>()
-					.okResponse({
-						page: pagination.page,
-						pageSize: pagination.pageSize,
-						totalCount: totalCount,
-						locationsReferences: locationsReferences,
-					})
-					.build(),
-			);
+		if (params?.asReference) {
+			const locationsReferences = await this.locationsService.listAsReferences(pagination, filter);
+			sendLocationsResponse({ locationsReferences });
 		} else {
-			res.status(404).send(new ErrorResponseBuilder().notFoundResponse("Locations not found").build());
+			const locations = await this.locationsService.list(pagination, filter);
+			sendLocationsResponse({ locations });
 		}
 	}
 
@@ -250,5 +231,28 @@ export class LocationsController implements ResourcePermissionController {
 		} else {
 			res.status(400).send(new ErrorResponseBuilder().badRequestResponse("Failed to archive the location").build());
 		}
+	}
+
+	getManagedByFilter(managedBy?: string) {
+		return managedBy ? { "manager.referenceId": managedBy } : undefined;
+	}
+
+	getEditableByFilter(editableBy?: string) {
+		return editableBy
+			? {
+					"metadata.editableBy": {
+						$in: [editableBy],
+					},
+			  }
+			: {};
+	}
+
+	getLocationsFilter(params?: Params): Filter {
+		const filter: Filter = {
+			...this.getManagedByFilter(params?.managedBy),
+			...this.getEditableByFilter(params?.editableBy),
+		};
+
+		return filter;
 	}
 }

--- a/src/resources/locations/controllers/LocationsController.ts
+++ b/src/resources/locations/controllers/LocationsController.ts
@@ -19,6 +19,7 @@ import { CreateLocationResponse } from "../../../generated/models/CreateLocation
 import { AuthUser } from "../../../generated/models/AuthUser.generated";
 import { CreateLocationRequest } from "../../../generated/models/CreateLocationRequest.generated";
 import { Params } from "../../../common/parameters/Params";
+import { getEditableByFilter } from "../../../utils/MetadataUtil";
 
 const log: debug.IDebugger = debug("app:locations-controller");
 
@@ -233,24 +234,14 @@ export class LocationsController implements ResourcePermissionController {
 		}
 	}
 
-	getManagedByFilter(managedBy?: string) {
+	private getManagedByFilter(managedBy?: string) {
 		return managedBy ? { "manager.referenceId": managedBy } : undefined;
 	}
 
-	getEditableByFilter(editableBy?: string) {
-		return editableBy
-			? {
-					"metadata.editableBy": {
-						$in: [editableBy],
-					},
-			  }
-			: {};
-	}
-
-	getLocationsFilter(params?: Params): Filter {
+	private getLocationsFilter(params?: Params): Filter {
 		const filter: Filter = {
 			...this.getManagedByFilter(params?.managedBy),
-			...this.getEditableByFilter(params?.editableBy),
+			...getEditableByFilter(params?.editableBy),
 		};
 
 		return filter;

--- a/src/resources/organizations/OrganizationsRoutes.ts
+++ b/src/resources/organizations/OrganizationsRoutes.ts
@@ -11,6 +11,7 @@ import { getPagination } from "../../utils/RequestUtil";
 import { Permit } from "../auth/middleware/Permit";
 import { OrganizationsController } from "./controllers/OrganizationsController";
 import { AuthUser } from "../../generated/models/AuthUser.generated";
+import { Params } from "../../common/parameters/Params";
 
 @Service()
 export class OrganizationsRoutes {
@@ -23,14 +24,13 @@ export class OrganizationsRoutes {
 
 		router
 			.get(OrganizationsRoutes.basePath + "/", (req: express.Request, res: express.Response) => {
-				const asReference = req.query.asReference;
 				const pagination: Pagination = getPagination(req);
+				const params: Params = {
+					asReference: req.query.asReference as string,
+					editableBy: req.query.editableBy as string,
+				};
 
-				if (asReference) {
-					this.organizationsController.listOrganizationsAsReference(res, pagination);
-				} else {
-					this.organizationsController.listOrganizations(res, pagination);
-				}
+				this.organizationsController.listOrganizations(res, pagination, params);
 			})
 			.post(
 				OrganizationsRoutes.basePath + "/",

--- a/src/resources/organizations/controllers/OrganizationsController.ts
+++ b/src/resources/organizations/controllers/OrganizationsController.ts
@@ -24,6 +24,7 @@ import { GetOrganizationMembershipResponse } from "../../../generated/models/Get
 import { AuthUser } from "../../../generated/models/AuthUser.generated";
 import { Params } from "../../../common/parameters/Params";
 import { Organization } from "../../../generated/models/Organization.generated";
+import { getEditableByFilter } from "../../../utils/MetadataUtil";
 
 const log: debug.IDebugger = debug("app:organizations-controller");
 
@@ -33,8 +34,6 @@ export class OrganizationsController implements ResourcePermissionController {
 		public organizationsService: OrganizationsService,
 		public userService: UsersService,
 	) {}
-
-
 
 	async listOrganizations(res: express.Response, pagination: Pagination, params?: Params) {
 		const filter: Filter = this.getOrganizationsFilter(params);
@@ -341,19 +340,9 @@ export class OrganizationsController implements ResourcePermissionController {
 		}
 	}
 
-	getEditableByFilter(editableBy?: string) {
-		return editableBy
-			? {
-					"metadata.editableBy": {
-						$in: [editableBy],
-					},
-			  }
-			: {};
-	}
-
-	getOrganizationsFilter(params?: Params): Filter {
+	private getOrganizationsFilter(params?: Params): Filter {
 		const filter: Filter = {
-			...this.getEditableByFilter(params?.editableBy),
+			...getEditableByFilter(params?.editableBy),
 		};
 
 		return filter;

--- a/src/resources/organizations/repositories/MongoDBOrganizationsRepository.ts
+++ b/src/resources/organizations/repositories/MongoDBOrganizationsRepository.ts
@@ -33,12 +33,12 @@ export class MongoDBOrganizationsRepository implements OrganizationsRepository {
 		return this.get(filter, undefined, pagination);
 	}
 
-	async getOrganizations(pagination?: Pagination): Promise<Organization[]> {
-		return this.get(undefined, undefined, pagination);
+	async getOrganizations(pagination?: Pagination, filter?: Filter): Promise<Organization[]> {
+		return this.get(filter, undefined, pagination);
 	}
 
-	async getOrganizationsAsReferences(pagination?: Pagination): Promise<Reference[]> {
-		return this.get(undefined, getOrganizationReferenceProjection(), pagination);
+	async getOrganizationsAsReferences(pagination?: Pagination, filter?: Filter): Promise<Reference[]> {
+		return this.get(filter, getOrganizationReferenceProjection(), pagination);
 	}
 
 	async searchAllOrganizations(filter: Filter, projection?: object): Promise<Organization[]> {

--- a/src/resources/organizations/repositories/OrganizationsRepository.ts
+++ b/src/resources/organizations/repositories/OrganizationsRepository.ts
@@ -10,9 +10,9 @@ import { AuthUser } from "../../../generated/models/AuthUser.generated";
 const log: debug.IDebugger = debug("app:organizations-repository");
 
 export interface OrganizationsRepository {
-	getOrganizations(pagination?: Pagination): Promise<Organization[]>;
+	getOrganizations(pagination?: Pagination, filter?: Filter): Promise<Organization[]>;
 
-	getOrganizationsAsReferences(pagination?: Pagination): Promise<Reference[]>;
+	getOrganizationsAsReferences(pagination?: Pagination, filter?: Filter): Promise<Reference[]>;
 
 	searchOrganizations(filter?: Filter, pagination?: Pagination): Promise<Organization[]>;
 

--- a/src/resources/organizations/services/OrganizationsService.ts
+++ b/src/resources/organizations/services/OrganizationsService.ts
@@ -12,12 +12,12 @@ import { AuthUser } from "../../../generated/models/AuthUser.generated";
 export class OrganizationsService {
 	constructor(@Inject("OrganizationsRepository") public organizationsRepository: OrganizationsRepository) {}
 
-	async list(pagination?: Pagination): Promise<Organization[]> {
-		return this.organizationsRepository.getOrganizations(pagination);
+	async list(pagination?: Pagination, searchFilter?: Filter): Promise<Organization[]> {
+		return this.organizationsRepository.getOrganizations(pagination, searchFilter);
 	}
 
-	async listAsReferences(pagination?: Pagination) {
-		return this.organizationsRepository.getOrganizationsAsReferences(pagination);
+	async listAsReferences(pagination?: Pagination, searchFilter?: Filter) {
+		return this.organizationsRepository.getOrganizationsAsReferences(pagination, searchFilter);
 	}
 
 	async search(filter?: Filter, pagination?: Pagination): Promise<Organization[]> {

--- a/src/schemas/kulturdaten.berlin.openapi.base.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.base.yml
@@ -90,6 +90,12 @@ paths:
           description: Returns only the Attractions curated by the entered Organization-ID
           schema:
             type: string
+        - name: editableBy
+          in: query
+          required: false
+          description: Returns only the Attractions editable by the entered Organization-ID
+          schema:
+            type: string
       responses:
         "200":
           description: OK

--- a/src/schemas/kulturdaten.berlin.openapi.base.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.base.yml
@@ -357,6 +357,25 @@ paths:
           description: Returns only the events organized by the entered Organization-ID
           schema:
             type: string
+        - name: editableBy
+          in: query
+          required: false
+          description: Returns only the events editable by the entered Organization-ID
+          schema:
+            type: string
+        - name: byLocation
+          in: query
+          required: false
+          description: Returns only the events occurring at the specified Location-ID
+          schema:
+            type: string
+        - name: byAttraction
+          in: query
+          required: false
+          description: Returns only the events that include the specified Attraction-ID
+          schema:
+            type: string
+           
       responses:
         "200":
           description: OK

--- a/src/schemas/kulturdaten.berlin.openapi.base.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.base.yml
@@ -1047,6 +1047,12 @@ paths:
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/asReference"
+        - name: editableBy
+          in: query
+          required: false
+          description: Returns only the organizations editable by the entered Organization-ID
+          schema:
+            type: string
       responses:
         "200":
           description: OK

--- a/src/schemas/kulturdaten.berlin.openapi.base.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.base.yml
@@ -754,6 +754,12 @@ paths:
           description: Returns only the locations managed by the entered Organization-ID
           schema:
             type: string
+        - name: editableBy
+          in: query
+          required: false
+          description: Returns only the locations editable by the entered Organization-ID
+          schema:
+            type: string
       responses:
         "200":
           description: OK

--- a/src/schemas/kulturdaten.berlin.openapi.generated.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.generated.yml
@@ -396,6 +396,24 @@ paths:
           description: Returns only the events organized by the entered Organization-ID
           schema:
             type: string
+        - name: editableBy
+          in: query
+          required: false
+          description: Returns only the events editable by the entered Organization-ID
+          schema:
+            type: string
+        - name: byLocation
+          in: query
+          required: false
+          description: Returns only the events occurring at the specified Location-ID
+          schema:
+            type: string
+        - name: byAttraction
+          in: query
+          required: false
+          description: Returns only the events that include the specified Attraction-ID
+          schema:
+            type: string
       responses:
         "200":
           description: OK

--- a/src/schemas/kulturdaten.berlin.openapi.generated.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.generated.yml
@@ -1052,6 +1052,14 @@ paths:
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/asReference"
+        - name: editableBy
+          in: query
+          required: false
+          description: >-
+            Returns only the organizations editable by the entered
+            Organization-ID
+          schema:
+            type: string
       responses:
         "200":
           description: OK

--- a/src/schemas/kulturdaten.berlin.openapi.generated.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.generated.yml
@@ -774,6 +774,12 @@ paths:
           description: Returns only the locations managed by the entered Organization-ID
           schema:
             type: string
+        - name: editableBy
+          in: query
+          required: false
+          description: Returns only the locations editable by the entered Organization-ID
+          schema:
+            type: string
       responses:
         "200":
           description: OK

--- a/src/schemas/kulturdaten.berlin.openapi.generated.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.generated.yml
@@ -124,6 +124,12 @@ paths:
           description: Returns only the Attractions curated by the entered Organization-ID
           schema:
             type: string
+        - name: editableBy
+          in: query
+          required: false
+          description: Returns only the Attractions editable by the entered Organization-ID
+          schema:
+            type: string
       responses:
         "200":
           description: OK

--- a/src/utils/MetadataUtil.ts
+++ b/src/utils/MetadataUtil.ts
@@ -33,3 +33,13 @@ export function createMetadata(creator?: Creator, existingMetadata?: Partial<Met
 export interface Creator {
 	organizationIdentifier?: string;
 }
+
+export function getEditableByFilter(editableBy?: string) {
+	return editableBy
+		? {
+				"metadata.editableBy": {
+					$in: [editableBy],
+				},
+		  }
+		: {};
+}


### PR DESCRIPTION
Location, Attraction, Event und Organization können jetzt per editableBy Path-Tag gefiltert werden. Hierbei gilt:

Es werden nur die Daten ausgegeben, die die OrganizationId des Felds editableBy im Array metadata.editableBy stehen haben.

Sind andere Filter aktiv, wird default eine UND Verknüpfung vorgenommen.

Nebenbei habe ich für Events noch die Filter byLocation und byAttraction implementiert, da dies "auf dem Weg" lag. Können durch diese Filter die GET admin/attractions Route überflüssig werden? Bin mir da nicht ganz sicher.