### PR TITLE
Fix: debug set-editableBy

### DIFF
--- a/src/admin/AdminRoutes.ts
+++ b/src/admin/AdminRoutes.ts
@@ -6,6 +6,7 @@ import { AttractionsController } from "../resources/attractions/controllers/Attr
 import { Permit } from "../resources/auth/middleware/Permit";
 import { getPagination } from "../utils/RequestUtil";
 import { DistrictDataHarvestersController } from "./districtData/controllers/DistrictDataHarvestersController";
+import { AuthUser } from "../generated/models/AuthUser.generated";
 
 const log: debug.IDebugger = debug("app:admin-routes");
 
@@ -24,8 +25,9 @@ export class AdminRoutes {
 			passport.authenticate("authenticated-user", { session: false }),
 			Permit.authorizesAsAdmin(),
 			(req: express.Request, res: express.Response) => {
+				const authUser = req.user as AuthUser;
 				const calendarIDs = req.body as string[];
-				this.districtDataHarvestersController.harvest(res, calendarIDs);
+				this.districtDataHarvestersController.harvest(res, calendarIDs, authUser);
 			},
 		);
 

--- a/src/admin/districtData/controllers/DistrictDataHarvestersController.ts
+++ b/src/admin/districtData/controllers/DistrictDataHarvestersController.ts
@@ -4,13 +4,14 @@ import { SuccessResponseBuilder } from "../../../common/responses/SuccessRespons
 import { Reference } from "../../../generated/models/Reference.generated";
 import { DistrictDataService } from "../services/DistrictDataService";
 import { HarvestResponse } from "../../../generated/models/HarvestResponse.generated";
+import { AuthUser } from "../../../generated/models/AuthUser.generated";
 
 @Service()
 export class DistrictDataHarvestersController {
 	constructor(public service: DistrictDataService) {}
 
-	async harvest(res: Response, calendarIDs: string[]) {
-		const harvestResult = await this.service.harvestDistrictData(calendarIDs);
+	async harvest(res: Response, calendarIDs: string[], authUser: AuthUser) {
+		const harvestResult = await this.service.harvestDistrictData(calendarIDs, authUser);
 
 		res.status(200).send(
 			new SuccessResponseBuilder<HarvestResponse>()

--- a/src/admin/districtData/services/DistrictDataMapper.ts
+++ b/src/admin/districtData/services/DistrictDataMapper.ts
@@ -6,7 +6,6 @@ import { CreateLocationRequest } from "../../../generated/models/CreateLocationR
 import { CreateOrganizationRequest } from "../../../generated/models/CreateOrganizationRequest.generated";
 import { Reference } from "../../../generated/models/Reference.generated";
 import { Tag } from "../../../generated/models/Tag.generated";
-import { getBoroughOfficeOrganizationID } from "../../../utils/IDUtil";
 import {
 	Barrierefreiheit,
 	Bezirke,
@@ -18,9 +17,7 @@ import {
 } from "../model/Bezirksdaten";
 
 export class DistrictDataMapper {
-	mapAttraction(veranstaltung: Veranstaltung, allTags: Tag[], bezirke?: Bezirke): CreateAttractionRequest {
-		const editableBy = this.getEditableBy(veranstaltung.event_bezirk_id, bezirke);
-
+	mapAttraction(veranstaltung: Veranstaltung, allTags: Tag[]): CreateAttractionRequest {
 		return {
 			title: {
 				...(veranstaltung.event_titel_de && { de: veranstaltung.event_titel_de }),
@@ -39,7 +36,6 @@ export class DistrictDataMapper {
 			metadata: {
 				origin: "bezirkskalender",
 				originObjectID: String(veranstaltung.event_id),
-				...(editableBy && { editableBy: [editableBy] }),
 			},
 			...(veranstaltung.event_homepage ? { website: veranstaltung.event_homepage } : {}),
 			inLanguages: this.getInLanguages(veranstaltung),
@@ -86,9 +82,7 @@ export class DistrictDataMapper {
 		attractionReference: Reference,
 		locationReference: Reference,
 		organizerReference: Reference,
-		bezirke?: Bezirke,
 	): CreateEventRequest {
-		const editableBy = this.getEditableBy(veranstaltung.event_bezirk_id, bezirke);
 		return {
 			schedule: {
 				startDate: termin.tag_von,
@@ -102,22 +96,18 @@ export class DistrictDataMapper {
 			metadata: {
 				origin: "bezirkskalender",
 				originObjectID: String(termin.id),
-				...(editableBy && { editableBy: [editableBy] }),
 			},
 			...(veranstaltung.event_ist_gratis === 1 && { admission: { ticketType: "ticketType.freeOfCharge" } }),
 		};
 	}
 
-	mapOrganisation(veranstalter: Veranstalter, bezirke: Bezirke): CreateOrganizationRequest {
-		const editableBy = this.getEditableBy(veranstalter.bezirk_id, bezirke);
-
+	mapOrganisation(veranstalter: Veranstalter): CreateOrganizationRequest {
 		return {
 			title: { de: veranstalter.name },
 			inLanguages: ["de"],
 			metadata: {
 				origin: "bezirkskalender",
 				originObjectID: String(veranstalter.id),
-				...(editableBy && { editableBy: [editableBy] }),
 			},
 		};
 	}
@@ -136,7 +126,6 @@ export class DistrictDataMapper {
 		if (veranstaltungsort.bezirk_id && bezirke[veranstaltungsort.bezirk_id].DE) {
 			boroughOfLocation = bezirke[veranstaltungsort.bezirk_id].DE.split(" ")[0] as Borough;
 		}
-		const editableBy = this.getEditableBy(veranstaltungsort.bezirk_id, bezirke);
 		return {
 			title: { de: veranstaltungsort.name },
 			isVirtual: false,
@@ -147,7 +136,6 @@ export class DistrictDataMapper {
 			metadata: {
 				origin: "bezirkskalender",
 				originObjectID: String(veranstaltungsort.id),
-				...(editableBy && { editableBy: [editableBy] }),
 			},
 		};
 	}
@@ -179,14 +167,5 @@ export class DistrictDataMapper {
 					: false,
 			)
 			.map((tag) => tag.identifier);
-	}
-
-	getEditableBy(bezirk_id: number | null, bezirke?: Bezirke): string | null {
-		if (bezirk_id && bezirke && bezirke[bezirk_id].DE) {
-			const borough = bezirke[bezirk_id].DE.split(" ")[0] as Borough;
-			return getBoroughOfficeOrganizationID(borough);
-		} else {
-			return null;
-		}
 	}
 }


### PR DESCRIPTION
Es gab ein Problem, das editableBy Feld für den Harvester zu setzen. 

Jetzt wird der Harvester-Nutzer als "Creator" gesetzt und schlüpft jeweils in die Rolle eines Vertreters des Bezirks für den jeweiligen Datensatz. 
Dadurch brauchen wir keine Sonderfälle beim Anlegen aus dem Harvester heraus.