### PR TITLE
Feat/embedding events to attraction

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -34,6 +34,8 @@ import { TagsRoutes } from "./resources/tags/tags.routes";
 import { UsersRoutes } from "./resources/users/UsersRoutes";
 import { MongoDBUsersRepository } from "./resources/users/repositories/MongoDBUsersRepository";
 import { UsersService } from "./resources/users/services/UsersService";
+import { MongoDBFilterFactory } from "./common/filter/FilterFactory";
+import { Attraction } from "./generated/models/Attraction.generated";
 
 export class KulturdatenBerlinApp {
 	constructor(public app: express.Application) {}
@@ -115,6 +117,8 @@ export class KulturdatenBerlinApp {
 
 		Container.set("TagsRepository", new MongoDBTagsRepository(Container.get("Database")));
 		Container.import([]);
+
+		Container.set("AttractionFilterFactory", new MongoDBFilterFactory<Attraction>());
 	}
 
 	private initLogger() {

--- a/src/app.ts
+++ b/src/app.ts
@@ -35,7 +35,6 @@ import { UsersRoutes } from "./resources/users/UsersRoutes";
 import { MongoDBUsersRepository } from "./resources/users/repositories/MongoDBUsersRepository";
 import { UsersService } from "./resources/users/services/UsersService";
 import { MongoDBFilterFactory } from "./common/filter/FilterFactory";
-import { Attraction } from "./generated/models/Attraction.generated";
 
 export class KulturdatenBerlinApp {
 	constructor(public app: express.Application) {}
@@ -118,7 +117,7 @@ export class KulturdatenBerlinApp {
 		Container.set("TagsRepository", new MongoDBTagsRepository(Container.get("Database")));
 		Container.import([]);
 
-		Container.set("AttractionFilterFactory", new MongoDBFilterFactory<Attraction>());
+		Container.set("FilterFactory", new MongoDBFilterFactory());
 	}
 
 	private initLogger() {

--- a/src/common/filter/FilterFactory.ts
+++ b/src/common/filter/FilterFactory.ts
@@ -6,6 +6,8 @@ export interface FilterFactory {
 
 	createPartialMatchFilter(propertyName: string, value: string | undefined): Filter | undefined;
 
+	createNotEqualFilter(propertyName: string, value: string | undefined): Filter | undefined;
+
 	createAnyMatchFilter(propertyName: string, values: string[] | undefined): Filter | undefined;
 
 	createAllMatchFilter(propertyName: string, values: string[] | undefined): Filter | undefined;
@@ -31,6 +33,13 @@ export class MongoDBFilterFactory implements FilterFactory {
 		return { [propertyName as string]: { $regex: value, $options: "i" } };
 	}
 
+	createNotEqualFilter(propertyName: string, value: string | undefined): Filter | undefined {
+		if (value === undefined) {
+			return undefined;
+		}
+		return { [propertyName]: { $ne: value } };
+	}
+
 	createAnyMatchFilter(propertyName: string, values: string[] | undefined): Filter | undefined {
 		if (!values) {
 			return undefined;
@@ -46,7 +55,7 @@ export class MongoDBFilterFactory implements FilterFactory {
 	}
 
 	combineWithAnd(filters: (Filter | undefined)[]): Filter {
-		const validFilters = filters.filter((f) => f !== undefined) as Filter[];
+		const validFilters = filters.filter((f) => f && Object.keys(f).length > 0) as Filter[];
 		if (validFilters.length > 0) {
 			return { $and: validFilters };
 		} else {
@@ -55,7 +64,7 @@ export class MongoDBFilterFactory implements FilterFactory {
 	}
 
 	combineWithOr(filters: (Filter | undefined)[]): Filter {
-		const validFilters = filters.filter((f) => f !== undefined) as Filter[];
+		const validFilters = filters.filter((f) => f && Object.keys(f).length > 0) as Filter[];
 		if (validFilters.length > 0) {
 			return { $or: validFilters };
 		} else {

--- a/src/common/filter/FilterFactory.ts
+++ b/src/common/filter/FilterFactory.ts
@@ -2,42 +2,64 @@ import { Service } from "typedi";
 import { Filter } from "../../generated/models/Filter.generated";
 
 export interface FilterFactory<T> {
-	createExactMatchFilter<K extends keyof T>(propertyName: K, value: T[K]): Filter;
+	createExactMatchFilter<K extends keyof T>(propertyName: K, value: T[K] | undefined): Filter | undefined;
 
-	createPartialMatchFilter<K extends keyof T>(propertyName: K, value: string): Filter;
+	createPartialMatchFilter<K extends keyof T>(propertyName: K, value: string | undefined): Filter | undefined;
 
-	createAnyMatchFilter<K extends keyof T>(propertyName: K, values: string[]): Filter;
+	createAnyMatchFilter<K extends keyof T>(propertyName: K, values: string[] | undefined): Filter | undefined;
 
-	createAllMatchFilter<K extends keyof T>(propertyName: K, values: string[]): Filter;
+	createAllMatchFilter<K extends keyof T>(propertyName: K, values: string[] | undefined): Filter | undefined;
 
-	combineWithAnd(filters: Filter[]): Filter;
+	combineWithAnd(filters: (Filter | undefined)[]): Filter;
 
-	combineWithOr(filters: Filter[]): Filter;
+	combineWithOr(filters: (Filter | undefined)[]): Filter;
 }
 
 @Service()
 export class MongoDBFilterFactory<T> implements FilterFactory<T> {
-	createExactMatchFilter<K extends keyof T>(propertyName: K, value: T[K]): Filter {
+	createExactMatchFilter<K extends keyof T>(propertyName: K, value: T[K] | undefined): Filter | undefined {
+		if (!value) {
+			return undefined;
+		}
 		return { [propertyName as string]: value };
 	}
 
-	createPartialMatchFilter<K extends keyof T>(propertyName: K, value: string): Filter {
+	createPartialMatchFilter<K extends keyof T>(propertyName: K, value: string | undefined): Filter | undefined {
+		if (!value) {
+			return undefined;
+		}
 		return { [propertyName as string]: { $regex: value, $options: "i" } };
 	}
 
-	createAnyMatchFilter<K extends keyof T>(propertyName: K, values: string[]): Filter {
+	createAnyMatchFilter<K extends keyof T>(propertyName: K, values: string[] | undefined): Filter | undefined {
+		if (!values) {
+			return undefined;
+		}
 		return { [propertyName as string]: { $in: values } };
 	}
 
-	createAllMatchFilter<K extends keyof T>(propertyName: K, values: string[]): Filter {
+	createAllMatchFilter<K extends keyof T>(propertyName: K, values: string[] | undefined): Filter | undefined {
+		if (!values) {
+			return undefined;
+		}
 		return { [propertyName as string]: { $all: values } };
 	}
 
-	combineWithAnd(filters: Filter[]): Filter {
-		return { $and: filters };
+	combineWithAnd(filters: (Filter | undefined)[]): Filter {
+		const validFilters = filters.filter((f) => f !== undefined) as Filter[];
+		if (validFilters.length > 0) {
+			return { $and: validFilters };
+		} else {
+			return {};
+		}
 	}
 
-	combineWithOr(filters: Filter[]): Filter {
-		return { $or: filters };
+	combineWithOr(filters: (Filter | undefined)[]): Filter {
+		const validFilters = filters.filter((f) => f !== undefined) as Filter[];
+		if (validFilters.length > 0) {
+			return { $or: validFilters };
+		} else {
+			return {};
+		}
 	}
 }

--- a/src/common/filter/FilterFactory.ts
+++ b/src/common/filter/FilterFactory.ts
@@ -12,6 +12,8 @@ export interface FilterFactory {
 
 	createAllMatchFilter(propertyName: string, values: string[] | undefined): Filter | undefined;
 
+	createFutureDateFilter(propertyName: string): Filter | undefined;
+
 	combineWithAnd(filters: (Filter | undefined)[]): Filter;
 
 	combineWithOr(filters: (Filter | undefined)[]): Filter;
@@ -52,6 +54,11 @@ export class MongoDBFilterFactory implements FilterFactory {
 			return undefined;
 		}
 		return { [propertyName as string]: { $all: values } };
+	}
+
+	createFutureDateFilter(propertyName: string): Filter | undefined {
+		const currentDate = new Date().toISOString().split("T")[0]; // YYYY-MM-DD Format
+		return { [propertyName]: { $gte: currentDate } };
 	}
 
 	combineWithAnd(filters: (Filter | undefined)[]): Filter {

--- a/src/common/filter/FilterFactory.ts
+++ b/src/common/filter/FilterFactory.ts
@@ -1,0 +1,41 @@
+import { Filter } from "../../generated/models/Filter.generated";
+
+export interface FilterFactory<T> {
+	createExactMatchFilter<K extends keyof T>(propertyName: K, value: T[K]): Filter;
+
+	createPartialMatchFilter<K extends keyof T>(propertyName: K, value: string): Filter;
+
+	createAnyMatchFilter<K extends keyof T>(propertyName: K, values: string[]): Filter;
+
+	createAllMatchFilter<K extends keyof T>(propertyName: K, values: string[]): Filter;
+
+	combineWithAnd(filters: Filter[]): Filter;
+
+	combineWithOr(filters: Filter[]): Filter;
+}
+
+export class SimpleFilterFactory<T> implements FilterFactory<T> {
+	createExactMatchFilter<K extends keyof T>(propertyName: K, value: T[K]): Filter {
+		return { [propertyName as string]: value };
+	}
+
+	createPartialMatchFilter<K extends keyof T>(propertyName: K, value: string): Filter {
+		return { [propertyName as string]: { $regex: value, $options: "i" } };
+	}
+
+	createAnyMatchFilter<K extends keyof T>(propertyName: K, values: string[]): Filter {
+		return { [propertyName as string]: { $in: values } };
+	}
+
+	createAllMatchFilter<K extends keyof T>(propertyName: K, values: string[]): Filter {
+		return { [propertyName as string]: { $all: values } };
+	}
+
+	combineWithAnd(filters: Filter[]): Filter {
+		return { $and: filters };
+	}
+
+	combineWithOr(filters: Filter[]): Filter {
+		return { $or: filters };
+	}
+}

--- a/src/common/filter/FilterFactory.ts
+++ b/src/common/filter/FilterFactory.ts
@@ -14,6 +14,13 @@ export interface FilterFactory {
 
 	createFutureDateFilter(propertyName: string): Filter | undefined;
 
+	createDateRangeFilter(
+		startDateProperty: string,
+		endDateProperty: string,
+		startDate?: string,
+		endDate?: string,
+	): Filter | undefined;
+
 	combineWithAnd(filters: (Filter | undefined)[]): Filter;
 
 	combineWithOr(filters: (Filter | undefined)[]): Filter;
@@ -59,6 +66,25 @@ export class MongoDBFilterFactory implements FilterFactory {
 	createFutureDateFilter(propertyName: string): Filter | undefined {
 		const currentDate = new Date().toISOString().split("T")[0]; // YYYY-MM-DD Format
 		return { [propertyName]: { $gte: currentDate } };
+	}
+
+	createDateRangeFilter(
+		startDateProperty: string,
+		endDateProperty: string,
+		startDate?: string,
+		endDate?: string,
+	): Filter | undefined {
+		if (startDate && endDate) {
+			return {
+				$and: [{ [startDateProperty]: { $gte: startDate } }, { [endDateProperty]: { $lte: endDate } }],
+			};
+		} else if (startDate) {
+			return { [startDateProperty]: { $gte: startDate } };
+		} else if (endDate) {
+			return { [endDateProperty]: { $lte: endDate } };
+		} else {
+			return undefined;
+		}
 	}
 
 	combineWithAnd(filters: (Filter | undefined)[]): Filter {

--- a/src/common/filter/FilterFactory.ts
+++ b/src/common/filter/FilterFactory.ts
@@ -1,3 +1,4 @@
+import { Service } from "typedi";
 import { Filter } from "../../generated/models/Filter.generated";
 
 export interface FilterFactory<T> {
@@ -14,7 +15,8 @@ export interface FilterFactory<T> {
 	combineWithOr(filters: Filter[]): Filter;
 }
 
-export class SimpleFilterFactory<T> implements FilterFactory<T> {
+@Service()
+export class MongoDBFilterFactory<T> implements FilterFactory<T> {
 	createExactMatchFilter<K extends keyof T>(propertyName: K, value: T[K]): Filter {
 		return { [propertyName as string]: value };
 	}

--- a/src/common/filter/FilterFactory.ts
+++ b/src/common/filter/FilterFactory.ts
@@ -1,14 +1,14 @@
 import { Service } from "typedi";
 import { Filter } from "../../generated/models/Filter.generated";
 
-export interface FilterFactory<T> {
-	createExactMatchFilter<K extends keyof T>(propertyName: K, value: T[K] | undefined): Filter | undefined;
+export interface FilterFactory {
+	createExactMatchFilter(propertyName: string, value: string | undefined): Filter | undefined;
 
-	createPartialMatchFilter<K extends keyof T>(propertyName: K, value: string | undefined): Filter | undefined;
+	createPartialMatchFilter(propertyName: string, value: string | undefined): Filter | undefined;
 
-	createAnyMatchFilter<K extends keyof T>(propertyName: K, values: string[] | undefined): Filter | undefined;
+	createAnyMatchFilter(propertyName: string, values: string[] | undefined): Filter | undefined;
 
-	createAllMatchFilter<K extends keyof T>(propertyName: K, values: string[] | undefined): Filter | undefined;
+	createAllMatchFilter(propertyName: string, values: string[] | undefined): Filter | undefined;
 
 	combineWithAnd(filters: (Filter | undefined)[]): Filter;
 
@@ -16,29 +16,29 @@ export interface FilterFactory<T> {
 }
 
 @Service()
-export class MongoDBFilterFactory<T> implements FilterFactory<T> {
-	createExactMatchFilter<K extends keyof T>(propertyName: K, value: T[K] | undefined): Filter | undefined {
+export class MongoDBFilterFactory implements FilterFactory {
+	createExactMatchFilter(propertyName: string, value: string | undefined): Filter | undefined {
 		if (!value) {
 			return undefined;
 		}
 		return { [propertyName as string]: value };
 	}
 
-	createPartialMatchFilter<K extends keyof T>(propertyName: K, value: string | undefined): Filter | undefined {
+	createPartialMatchFilter(propertyName: string, value: string | undefined): Filter | undefined {
 		if (!value) {
 			return undefined;
 		}
 		return { [propertyName as string]: { $regex: value, $options: "i" } };
 	}
 
-	createAnyMatchFilter<K extends keyof T>(propertyName: K, values: string[] | undefined): Filter | undefined {
+	createAnyMatchFilter(propertyName: string, values: string[] | undefined): Filter | undefined {
 		if (!values) {
 			return undefined;
 		}
 		return { [propertyName as string]: { $in: values } };
 	}
 
-	createAllMatchFilter<K extends keyof T>(propertyName: K, values: string[] | undefined): Filter | undefined {
+	createAllMatchFilter(propertyName: string, values: string[] | undefined): Filter | undefined {
 		if (!values) {
 			return undefined;
 		}

--- a/src/common/filter/FilterFactory.unit.test.ts
+++ b/src/common/filter/FilterFactory.unit.test.ts
@@ -1,11 +1,10 @@
-import { Attraction } from "../../generated/models/Attraction.generated";
 import { FilterFactory, MongoDBFilterFactory } from "./FilterFactory";
 
 describe("MongoDBFilterFactory", () => {
-	let factory: FilterFactory<Attraction>;
+	let factory: FilterFactory;
 
 	beforeEach(() => {
-		factory = new MongoDBFilterFactory<Attraction>();
+		factory = new MongoDBFilterFactory();
 	});
 
 	it("should create an exact match filter", () => {

--- a/src/common/filter/FilterFactory.unit.test.ts
+++ b/src/common/filter/FilterFactory.unit.test.ts
@@ -1,11 +1,11 @@
 import { Attraction } from "../../generated/models/Attraction.generated";
-import { SimpleFilterFactory } from "./FilterFactory";
+import { FilterFactory, MongoDBFilterFactory } from "./FilterFactory";
 
-describe("SimpleFilterFactory", () => {
-	let factory: SimpleFilterFactory<Attraction>;
+describe("MongoDBFilterFactory", () => {
+	let factory: FilterFactory<Attraction>;
 
 	beforeEach(() => {
-		factory = new SimpleFilterFactory<Attraction>();
+		factory = new MongoDBFilterFactory<Attraction>();
 	});
 
 	it("should create an exact match filter", () => {

--- a/src/common/filter/FilterFactory.unit.test.ts
+++ b/src/common/filter/FilterFactory.unit.test.ts
@@ -1,0 +1,44 @@
+import { Attraction } from "../../generated/models/Attraction.generated";
+import { SimpleFilterFactory } from "./FilterFactory";
+
+describe("SimpleFilterFactory", () => {
+	let factory: SimpleFilterFactory<Attraction>;
+
+	beforeEach(() => {
+		factory = new SimpleFilterFactory<Attraction>();
+	});
+
+	it("should create an exact match filter", () => {
+		const filter = factory.createExactMatchFilter("identifier", "123");
+		expect(filter).toEqual({ identifier: "123" });
+	});
+
+	it("should create a partial match filter", () => {
+		const filter = factory.createPartialMatchFilter("identifier", "123");
+		expect(filter).toEqual({ identifier: { $regex: "123", $options: "i" } });
+	});
+
+	it("should create an any match filter", () => {
+		const filter = factory.createAnyMatchFilter("tags", ["tag1", "tag2"]);
+		expect(filter).toEqual({ tags: { $in: ["tag1", "tag2"] } });
+	});
+
+	it("should create an all match filter", () => {
+		const filter = factory.createAllMatchFilter("tags", ["tag1", "tag2"]);
+		expect(filter).toEqual({ tags: { $all: ["tag1", "tag2"] } });
+	});
+
+	it("should combine filters with AND", () => {
+		const filter1 = { identifier: "123" };
+		const filter2 = { type: "type.Attraction" };
+		const combinedFilter = factory.combineWithAnd([filter1, filter2]);
+		expect(combinedFilter).toEqual({ $and: [filter1, filter2] });
+	});
+
+	it("should combine filters with OR", () => {
+		const filter1 = { identifier: "123" };
+		const filter2 = { type: "type.Attraction" };
+		const combinedFilter = factory.combineWithOr([filter1, filter2]);
+		expect(combinedFilter).toEqual({ $or: [filter1, filter2] });
+	});
+});

--- a/src/common/parameters/Params.ts
+++ b/src/common/parameters/Params.ts
@@ -1,5 +1,5 @@
 export type Params = {
-	[key: string]: string | string[] | undefined;
+	[key: string]: string | string[] | boolean | undefined;
 };
 
 export type AttractionParams = Params & {
@@ -15,6 +15,7 @@ export type EventParams = Params & {
 	editableBy?: string;
 	byLocation?: string;
 	byAttraction?: string;
+	isFreeOfCharge?: boolean;
 };
 
 export type LocationParams = Params & {

--- a/src/common/parameters/Params.ts
+++ b/src/common/parameters/Params.ts
@@ -7,6 +7,7 @@ export type AttractionParams = Params & {
 	editableBy?: string;
 	anyTags?: string[];
 	allTags?: string[];
+	withEvents?: boolean;
 };
 
 export type EventParams = Params & {

--- a/src/common/parameters/Params.ts
+++ b/src/common/parameters/Params.ts
@@ -16,6 +16,7 @@ export type EventParams = Params & {
 	byLocation?: string;
 	byAttraction?: string;
 	isFreeOfCharge?: boolean;
+	inFuture?: boolean;
 };
 
 export type LocationParams = Params & {

--- a/src/common/parameters/Params.ts
+++ b/src/common/parameters/Params.ts
@@ -5,7 +5,8 @@ export type Params = {
 export type AttractionParams = Params & {
 	curatedBy?: string;
 	editableBy?: string;
-	tags?: string[];
+	anyTags?: string[];
+	allTags?: string[];
 };
 
 export type EventParams = Params & {

--- a/src/common/parameters/Params.ts
+++ b/src/common/parameters/Params.ts
@@ -17,6 +17,8 @@ export type EventParams = Params & {
 	byAttraction?: string;
 	isFreeOfCharge?: boolean;
 	inFuture?: boolean;
+	startDate?: string;
+	endDate?: string;
 };
 
 export type LocationParams = Params & {

--- a/src/common/parameters/Params.ts
+++ b/src/common/parameters/Params.ts
@@ -21,6 +21,8 @@ export type LocationParams = Params & {
 	asReference?: string;
 	managedBy?: string;
 	editableBy?: string;
+	anyAccessibilities?: string[];
+	allAccessibilities?: string[];
 };
 
 export type OrganizationParams = Params & {

--- a/src/common/parameters/Params.ts
+++ b/src/common/parameters/Params.ts
@@ -1,3 +1,28 @@
 export type Params = {
-	[key: string]: string;
+	[key: string]: string | string[] | undefined;
+};
+
+export type AttractionParams = Params & {
+	curatedBy?: string;
+	editableBy?: string;
+	tags?: string[];
+};
+
+export type EventParams = Params & {
+	asReference?: string;
+	organizedBy?: string;
+	editableBy?: string;
+	byLocation?: string;
+	byAttraction?: string;
+};
+
+export type LocationParams = Params & {
+	asReference?: string;
+	managedBy?: string;
+	editableBy?: string;
+};
+
+export type OrganizationParams = Params & {
+	asReference?: string;
+	editableBy?: string;
 };

--- a/src/common/responses/SuccessResponseBuilder.ts
+++ b/src/common/responses/SuccessResponseBuilder.ts
@@ -4,6 +4,7 @@ export class SuccessResponseBuilder<T extends Response> {
 	private success: boolean = true;
 	private message?: string;
 	private data?: T["data"];
+	private related?: T["related"];
 
 	setMessage(message: string): SuccessResponseBuilder<T> {
 		this.message = message;
@@ -15,15 +16,22 @@ export class SuccessResponseBuilder<T extends Response> {
 		return this;
 	}
 
-	okResponse(data?: T["data"]): SuccessResponseBuilder<T> {
-		this.message = "Operation Successful";
-		this.data = data;
+	setRelated(related: T["related"]): SuccessResponseBuilder<T> {
+		this.related = related;
 		return this;
 	}
 
-	createdResponse(data?: T["data"]): SuccessResponseBuilder<T> {
+	okResponse(data?: T["data"], related?: T["related"]): SuccessResponseBuilder<T> {
+		this.message = "Operation Successful";
+		this.data = data;
+		this.related = related;
+		return this;
+	}
+
+	createdResponse(data?: T["data"], related?: T["related"]): SuccessResponseBuilder<T> {
 		this.message = "Resource Created";
 		this.data = data;
+		this.related = related;
 		return this;
 	}
 
@@ -32,6 +40,7 @@ export class SuccessResponseBuilder<T extends Response> {
 			success: this.success,
 			message: this.message,
 			data: this.data,
+			related: this.related,
 		} as T;
 	}
 }

--- a/src/common/services/MongoDBConnector.ts
+++ b/src/common/services/MongoDBConnector.ts
@@ -72,6 +72,7 @@ export class MongoDBConnector {
 
 		const attractions = await this.attractions();
 		await attractions.createIndex({ identifier: 1 }, { name: "id_index" });
+		await attractions.createIndex({ "attractions.referenceId": 1 }, { name: "attractions_referenceId_index" });
 
 		const tags = await this.tags();
 		await tags.createIndex({ identifier: 1 }, { name: "id_index" });

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -2,6 +2,7 @@ export const pagination = {
 	defaultPage: 1,
 	defaultPageSize: 30,
 	maxPageSize: 500,
+	maxComplexRequestPageSize: 30,
 };
 
 export const MONGO_DB_DEFAULT_PROJECTION = {

--- a/src/integrationtests/EventsResources.integration.test.ts
+++ b/src/integrationtests/EventsResources.integration.test.ts
@@ -203,6 +203,7 @@ describe("Search events", () => {
 			new FindEventsByLocationAccessibilityTagsFilterStrategy(env.eventsRepository, env.locationsRepository),
 			findInTheFutureStrategy,
 		];
+		console.log("Search events setup done " + env.eventsService.filterStrategies);
 	});
 
 	afterEach(async () => {

--- a/src/integrationtests/integrationtestutils/TestEnvironment.ts
+++ b/src/integrationtests/integrationtestutils/TestEnvironment.ts
@@ -29,6 +29,7 @@ import { UsersRepository } from "../../resources/users/repositories/UsersReposit
 import { UsersService } from "../../resources/users/services/UsersService";
 import { MongoDBUsersRepository } from "../../resources/users/repositories/MongoDBUsersRepository";
 import { AuthUser } from "../../generated/models/AuthUser.generated";
+import { MongoDBFilterFactory } from "../../common/filter/FilterFactory";
 
 export class TestEnvironment {
 	createUser(
@@ -120,7 +121,7 @@ export class TestEnvironment {
 	withEventsRoutes(): TestEnvironment {
 		this.eventsRepository = new MongoDBEventsRepository(this.connector);
 		this.eventsService = new EventsService(this.eventsRepository);
-		this.eventsController = new EventsController(this.eventsService);
+		this.eventsController = new EventsController(this.eventsService, new MongoDBFilterFactory());
 		this.eventsRoutes = new EventsRoutes(this.eventsController);
 		this.events = this.db.collection("events");
 		this.app.use("/", this.eventsRoutes.getRouter());
@@ -131,7 +132,7 @@ export class TestEnvironment {
 	withLocationsRoutes(): TestEnvironment {
 		this.locationsRepository = new MongoDBLocationsRepository(this.connector);
 		this.locationsService = new LocationsService(this.locationsRepository);
-		this.locationsController = new LocationsController(this.locationsService);
+		this.locationsController = new LocationsController(this.locationsService, new MongoDBFilterFactory());
 		this.locationsRoutes = new LocationsRoutes(this.locationsController);
 		this.locations = this.db.collection("locations");
 		this.app.use("/", this.locationsRoutes.getRouter());
@@ -146,7 +147,11 @@ export class TestEnvironment {
 
 		this.organizationsRepository = new MongoDBOrganizationsRepository(this.connector);
 		this.organizationsService = new OrganizationsService(this.organizationsRepository);
-		this.organizationsController = new OrganizationsController(this.organizationsService, this.usersService);
+		this.organizationsController = new OrganizationsController(
+			this.organizationsService,
+			this.usersService,
+			new MongoDBFilterFactory(),
+		);
 		this.organizationsRoutes = new OrganizationsRoutes(this.organizationsController);
 		this.organizations = this.db.collection("organizations");
 		this.app.use("/", this.organizationsRoutes.getRouter());
@@ -157,7 +162,7 @@ export class TestEnvironment {
 	withAttractionsRoutes(): TestEnvironment {
 		this.attractionsRepository = new MongoDBAttractionsRepository(this.connector);
 		this.attractionsService = new AttractionsService(this.attractionsRepository, this.eventsRepository);
-		this.attractionsController = new AttractionsController(this.attractionsService);
+		this.attractionsController = new AttractionsController(this.attractionsService, new MongoDBFilterFactory());
 		this.attractionsRoutes = new AttractionsRoutes(this.attractionsController);
 		this.attractions = this.db.collection("attractions");
 		this.app.use("/", this.attractionsRoutes.getRouter());

--- a/src/integrationtests/integrationtestutils/TestEnvironment.ts
+++ b/src/integrationtests/integrationtestutils/TestEnvironment.ts
@@ -119,58 +119,59 @@ export class TestEnvironment {
 	}
 
 	withEventsRoutes(): TestEnvironment {
-		this.eventsRepository = new MongoDBEventsRepository(this.connector);
-		this.eventsService = new EventsService(this.eventsRepository);
-		this.eventsController = new EventsController(this.eventsService, new MongoDBFilterFactory());
-		this.eventsRoutes = new EventsRoutes(this.eventsController);
-		this.events = this.db.collection("events");
+		this.eventsRepository = this.eventsRepository || new MongoDBEventsRepository(this.connector);
+		this.eventsService = this.eventsService || new EventsService(this.eventsRepository);
+		this.eventsController =
+			this.eventsController || new EventsController(this.eventsService, new MongoDBFilterFactory());
+		this.eventsRoutes = this.eventsRoutes || new EventsRoutes(this.eventsController);
+		this.events = this.events || this.db.collection("events");
 		this.app.use("/", this.eventsRoutes.getRouter());
 
 		return this;
 	}
 
 	withLocationsRoutes(): TestEnvironment {
-		this.locationsRepository = new MongoDBLocationsRepository(this.connector);
-		this.locationsService = new LocationsService(this.locationsRepository);
-		this.locationsController = new LocationsController(this.locationsService, new MongoDBFilterFactory());
-		this.locationsRoutes = new LocationsRoutes(this.locationsController);
-		this.locations = this.db.collection("locations");
+		this.locationsRepository = this.locationsRepository || new MongoDBLocationsRepository(this.connector);
+		this.locationsService = this.locationsService || new LocationsService(this.locationsRepository);
+		this.locationsController =
+			this.locationsController || new LocationsController(this.locationsService, new MongoDBFilterFactory());
+		this.locationsRoutes = this.locationsRoutes || new LocationsRoutes(this.locationsController);
+		this.locations = this.locations || this.db.collection("locations");
 		this.app.use("/", this.locationsRoutes.getRouter());
 
 		return this;
 	}
 
 	withOrganizationsRoutes(): TestEnvironment {
-		this.usersRepository = new MongoDBUsersRepository(this.connector);
-		this.usersService = new UsersService(this.usersRepository);
-		this.users = this.db.collection("users");
+		this.usersRepository = this.usersRepository || new MongoDBUsersRepository(this.connector);
+		this.usersService = this.usersService || new UsersService(this.usersRepository);
+		this.users = this.users || this.db.collection("users");
 
-		this.organizationsRepository = new MongoDBOrganizationsRepository(this.connector);
-		this.organizationsService = new OrganizationsService(this.organizationsRepository);
-		this.organizationsController = new OrganizationsController(
-			this.organizationsService,
-			this.usersService,
-			new MongoDBFilterFactory(),
-		);
-		this.organizationsRoutes = new OrganizationsRoutes(this.organizationsController);
-		this.organizations = this.db.collection("organizations");
+		this.organizationsRepository = this.organizationsRepository || new MongoDBOrganizationsRepository(this.connector);
+		this.organizationsService = this.organizationsService || new OrganizationsService(this.organizationsRepository);
+		this.organizationsController =
+			this.organizationsController ||
+			new OrganizationsController(this.organizationsService, this.usersService, new MongoDBFilterFactory());
+		this.organizationsRoutes = this.organizationsRoutes || new OrganizationsRoutes(this.organizationsController);
+		this.organizations = this.organizations || this.db.collection("organizations");
 		this.app.use("/", this.organizationsRoutes.getRouter());
 
 		return this;
 	}
 
 	withAttractionsRoutes(): TestEnvironment {
-		this.attractionsRepository = new MongoDBAttractionsRepository(this.connector);
-		this.attractionsService = new AttractionsService(this.attractionsRepository, this.eventsRepository);
-		this.eventsRepository = new MongoDBEventsRepository(this.connector);
-		this.eventsService = new EventsService(this.eventsRepository);
-		this.attractionsController = new AttractionsController(
-			this.attractionsService,
-			this.eventsService,
-			new MongoDBFilterFactory(),
-		);
-		this.attractionsRoutes = new AttractionsRoutes(this.attractionsController);
-		this.attractions = this.db.collection("attractions");
+		this.eventsRepository = this.eventsRepository || new MongoDBEventsRepository(this.connector);
+		this.eventsService = this.eventsService || new EventsService(this.eventsRepository);
+
+		this.attractionsRepository = this.attractionsRepository || new MongoDBAttractionsRepository(this.connector);
+		this.attractionsService =
+			this.attractionsService || new AttractionsService(this.attractionsRepository, this.eventsRepository);
+
+		this.attractionsController =
+			this.attractionsController ||
+			new AttractionsController(this.attractionsService, this.eventsService, new MongoDBFilterFactory());
+		this.attractionsRoutes = this.attractionsRoutes || new AttractionsRoutes(this.attractionsController);
+		this.attractions = this.attractions || this.db.collection("attractions");
 		this.app.use("/", this.attractionsRoutes.getRouter());
 
 		return this;

--- a/src/integrationtests/integrationtestutils/TestEnvironment.ts
+++ b/src/integrationtests/integrationtestutils/TestEnvironment.ts
@@ -162,7 +162,13 @@ export class TestEnvironment {
 	withAttractionsRoutes(): TestEnvironment {
 		this.attractionsRepository = new MongoDBAttractionsRepository(this.connector);
 		this.attractionsService = new AttractionsService(this.attractionsRepository, this.eventsRepository);
-		this.attractionsController = new AttractionsController(this.attractionsService, new MongoDBFilterFactory());
+		this.eventsRepository = new MongoDBEventsRepository(this.connector);
+		this.eventsService = new EventsService(this.eventsRepository);
+		this.attractionsController = new AttractionsController(
+			this.attractionsService,
+			this.eventsService,
+			new MongoDBFilterFactory(),
+		);
 		this.attractionsRoutes = new AttractionsRoutes(this.attractionsController);
 		this.attractions = this.db.collection("attractions");
 		this.app.use("/", this.attractionsRoutes.getRouter());

--- a/src/resources/attractions/AttractionsRoutes.ts
+++ b/src/resources/attractions/AttractionsRoutes.ts
@@ -27,7 +27,6 @@ export class AttractionsRoutes {
 
 		router
 			.get(AttractionsRoutes.basePath + "/", (req: express.Request, res: express.Response) => {
-				const pagination: Pagination = getPagination(req);
 				const anyTags: string[] | undefined = extractArrayQueryParam(req, "anyTags");
 				const allTags: string[] | undefined = extractArrayQueryParam(req, "allTags");
 				const params: AttractionParams = {
@@ -38,7 +37,7 @@ export class AttractionsRoutes {
 					allTags: allTags,
 					withEvents: parseBooleanParameter(req, "withEvents"),
 				};
-
+				const pagination: Pagination = getPagination(req, params.withEvents);
 				this.attractionsController.listAttractions(res, pagination, params);
 			})
 			.post(

--- a/src/resources/attractions/AttractionsRoutes.ts
+++ b/src/resources/attractions/AttractionsRoutes.ts
@@ -8,7 +8,7 @@ import { CreateAttractionRequest } from "../../generated/models/CreateAttraction
 import { RemoveExternalLinkRequest } from "../../generated/models/RemoveExternalLinkRequest.generated";
 import { SearchAttractionsRequest } from "../../generated/models/SearchAttractionsRequest.generated";
 import { UpdateAttractionRequest } from "../../generated/models/UpdateAttractionRequest.generated";
-import { extractArrayQueryParam, getPagination } from "../../utils/RequestUtil";
+import { extractArrayQueryParam, getPagination, parseBooleanParameter } from "../../utils/RequestUtil";
 import { AttractionsController } from "./controllers/AttractionsController";
 import { Permit } from "../auth/middleware/Permit";
 import { AuthUser } from "../../generated/models/AuthUser.generated";
@@ -36,6 +36,7 @@ export class AttractionsRoutes {
 					editableBy: req.query.editableBy as string,
 					anyTags: anyTags,
 					allTags: allTags,
+					withEvents: parseBooleanParameter(req, "withEvents"),
 				};
 
 				this.attractionsController.listAttractions(res, pagination, params);

--- a/src/resources/attractions/AttractionsRoutes.ts
+++ b/src/resources/attractions/AttractionsRoutes.ts
@@ -12,7 +12,7 @@ import { getPagination } from "../../utils/RequestUtil";
 import { AttractionsController } from "./controllers/AttractionsController";
 import { Permit } from "../auth/middleware/Permit";
 import { AuthUser } from "../../generated/models/AuthUser.generated";
-import { Params } from "../../common/parameters/Params";
+import { AttractionParams } from "../../common/parameters/Params";
 
 const log: debug.IDebugger = debug("app:attractions-routes");
 
@@ -28,7 +28,7 @@ export class AttractionsRoutes {
 		router
 			.get(AttractionsRoutes.basePath + "/", (req: express.Request, res: express.Response) => {
 				const pagination: Pagination = getPagination(req);
-				const params: Params = {
+				const params: AttractionParams = {
 					asReference: req.query.asReference as string,
 					curatedBy: req.query.curatedBy as string,
 					editableBy: req.query.editableBy as string,

--- a/src/resources/attractions/AttractionsRoutes.ts
+++ b/src/resources/attractions/AttractionsRoutes.ts
@@ -74,12 +74,11 @@ export class AttractionsRoutes {
 		router
 			.get(AttractionsRoutes.basePath + "/:identifier", (req: express.Request, res: express.Response) => {
 				const identifier = req.params.identifier;
-				const asReference = req.query.asReference;
-				if (asReference) {
-					this.attractionsController.getAttractionReferenceById(res, identifier);
-				} else {
-					this.attractionsController.getAttractionById(res, identifier);
-				}
+				const params: AttractionParams = {
+					asReference: req.query.asReference as string,
+					withEvents: parseBooleanParameter(req, "withEvents"),
+				};
+				this.attractionsController.getAttractionById(res, identifier, params);
 			})
 			.patch(
 				AttractionsRoutes.basePath + "/:identifier",

--- a/src/resources/attractions/AttractionsRoutes.ts
+++ b/src/resources/attractions/AttractionsRoutes.ts
@@ -8,7 +8,7 @@ import { CreateAttractionRequest } from "../../generated/models/CreateAttraction
 import { RemoveExternalLinkRequest } from "../../generated/models/RemoveExternalLinkRequest.generated";
 import { SearchAttractionsRequest } from "../../generated/models/SearchAttractionsRequest.generated";
 import { UpdateAttractionRequest } from "../../generated/models/UpdateAttractionRequest.generated";
-import { getPagination } from "../../utils/RequestUtil";
+import { extractArrayQueryParam, getPagination } from "../../utils/RequestUtil";
 import { AttractionsController } from "./controllers/AttractionsController";
 import { Permit } from "../auth/middleware/Permit";
 import { AuthUser } from "../../generated/models/AuthUser.generated";
@@ -28,10 +28,14 @@ export class AttractionsRoutes {
 		router
 			.get(AttractionsRoutes.basePath + "/", (req: express.Request, res: express.Response) => {
 				const pagination: Pagination = getPagination(req);
+				const anyTags: string[] | undefined = extractArrayQueryParam(req, "anyTags");
+				const allTags: string[] | undefined = extractArrayQueryParam(req, "allTags");
 				const params: AttractionParams = {
 					asReference: req.query.asReference as string,
 					curatedBy: req.query.curatedBy as string,
 					editableBy: req.query.editableBy as string,
+					anyTags: anyTags,
+					allTags: allTags,
 				};
 
 				this.attractionsController.listAttractions(res, pagination, params);

--- a/src/resources/attractions/controllers/AttractionsController.ts
+++ b/src/resources/attractions/controllers/AttractionsController.ts
@@ -18,7 +18,7 @@ import { AttractionsService } from "../services/AttractionsService";
 import { ResourcePermissionController } from "../../auth/controllers/ResourcePermissionController";
 import { Filter } from "../../../generated/models/Filter.generated";
 import { AuthUser } from "../../../generated/models/AuthUser.generated";
-import { Params } from "../../../common/parameters/Params";
+import { AttractionParams } from "../../../common/parameters/Params";
 import { Attraction } from "../../../generated/models/Attraction.generated";
 import { getEditableByFilter } from "../../../utils/MetadataUtil";
 
@@ -26,7 +26,7 @@ import { getEditableByFilter } from "../../../utils/MetadataUtil";
 export class AttractionsController implements ResourcePermissionController {
 	constructor(public attractionsService: AttractionsService) {}
 
-	async listAttractions(res: Response, pagination: Pagination, params?: Params) {
+	async listAttractions(res: Response, pagination: Pagination, params?: AttractionParams) {
 		const filter: Filter = this.getAttractionsFilter(params);
 		const totalCount = await this.attractionsService.countAttractions(filter);
 
@@ -253,7 +253,7 @@ export class AttractionsController implements ResourcePermissionController {
 		return curatedBy ? { "curator.referenceId": curatedBy } : {};
 	}
 
-	private getAttractionsFilter(params?: Params): Filter {
+	private getAttractionsFilter(params?: AttractionParams): Filter {
 		const filter: Filter = {
 			...this.getCuratedByFilter(params?.curatedBy),
 			...getEditableByFilter(params?.editableBy),

--- a/src/resources/attractions/controllers/AttractionsController.ts
+++ b/src/resources/attractions/controllers/AttractionsController.ts
@@ -27,7 +27,7 @@ import { FilterFactory } from "../../../common/filter/FilterFactory";
 export class AttractionsController implements ResourcePermissionController {
 	constructor(
 		public attractionsService: AttractionsService,
-		@Inject("AttractionFilterFactory") public filterFactory: FilterFactory<Attraction>,
+		@Inject("FilterFactory") public filterFactory: FilterFactory,
 	) {}
 
 	async listAttractions(res: Response, pagination: Pagination, params?: AttractionParams) {

--- a/src/resources/events/EventsRoutes.ts
+++ b/src/resources/events/EventsRoutes.ts
@@ -41,6 +41,8 @@ export class EventsRoutes {
 					byAttraction: req.query.byAttraction as string,
 					isFreeOfCharge: parseBooleanParameter(req, "isFreeOfCharge"),
 					inFuture: parseBooleanParameter(req, "inFuture"),
+					startDate: req.query.startDate as string,
+					endDate: req.query.endDate as string,
 				};
 
 				this.eventsController.listEvents(res, pagination, params);

--- a/src/resources/events/EventsRoutes.ts
+++ b/src/resources/events/EventsRoutes.ts
@@ -38,6 +38,7 @@ export class EventsRoutes {
 					editableBy: req.query.editableBy as string,
 					byLocation: req.query.byLocation as string,
 					byAttraction: req.query.byAttraction as string,
+					isFreeOfCharge: req.query.isFreeOfCharge === "true",
 				};
 
 				this.eventsController.listEvents(res, pagination, params);

--- a/src/resources/events/EventsRoutes.ts
+++ b/src/resources/events/EventsRoutes.ts
@@ -11,7 +11,7 @@ import { RescheduleEventRequest } from "../../generated/models/RescheduleEventRe
 import { SearchEventsRequest } from "../../generated/models/SearchEventsRequest.generated";
 import { SetEventOrganizerRequest } from "../../generated/models/SetEventOrganizerRequest.generated";
 import { UpdateEventRequest } from "../../generated/models/UpdateEventRequest.generated";
-import { getPagination } from "../../utils/RequestUtil";
+import { getPagination, parseBooleanParameter } from "../../utils/RequestUtil";
 import { EventsController } from "./controllers/EventsController";
 import { Permit } from "../auth/middleware/Permit";
 import { AuthUser } from "../../generated/models/AuthUser.generated";
@@ -32,13 +32,14 @@ export class EventsRoutes {
 		router
 			.get(EventsRoutes.basePath + "/", (req: express.Request, res: express.Response) => {
 				const pagination: Pagination = getPagination(req);
+
 				const params: EventParams = {
 					asReference: req.query.asReference as string,
 					organizedBy: req.query.organizedBy as string,
 					editableBy: req.query.editableBy as string,
 					byLocation: req.query.byLocation as string,
 					byAttraction: req.query.byAttraction as string,
-					isFreeOfCharge: req.query.isFreeOfCharge === "true",
+					isFreeOfCharge: parseBooleanParameter(req, "isFreeOfCharge"),
 				};
 
 				this.eventsController.listEvents(res, pagination, params);

--- a/src/resources/events/EventsRoutes.ts
+++ b/src/resources/events/EventsRoutes.ts
@@ -40,6 +40,7 @@ export class EventsRoutes {
 					byLocation: req.query.byLocation as string,
 					byAttraction: req.query.byAttraction as string,
 					isFreeOfCharge: parseBooleanParameter(req, "isFreeOfCharge"),
+					inFuture: parseBooleanParameter(req, "inFuture"),
 				};
 
 				this.eventsController.listEvents(res, pagination, params);

--- a/src/resources/events/EventsRoutes.ts
+++ b/src/resources/events/EventsRoutes.ts
@@ -16,7 +16,7 @@ import { EventsController } from "./controllers/EventsController";
 import { Permit } from "../auth/middleware/Permit";
 import { AuthUser } from "../../generated/models/AuthUser.generated";
 import { CreateEventRequest } from "../../generated/models/CreateEventRequest.generated";
-import { Params } from "../../common/parameters/Params";
+import { EventParams } from "../../common/parameters/Params";
 
 const log: debug.IDebugger = debug("app:events-routes");
 
@@ -32,7 +32,7 @@ export class EventsRoutes {
 		router
 			.get(EventsRoutes.basePath + "/", (req: express.Request, res: express.Response) => {
 				const pagination: Pagination = getPagination(req);
-				const params: Params = {
+				const params: EventParams = {
 					asReference: req.query.asReference as string,
 					organizedBy: req.query.organizedBy as string,
 					editableBy: req.query.editableBy as string,

--- a/src/resources/events/controllers/EventsController.ts
+++ b/src/resources/events/controllers/EventsController.ts
@@ -20,7 +20,7 @@ import { ResourcePermissionController } from "../../auth/controllers/ResourcePer
 import { Filter } from "../../../generated/models/Filter.generated";
 import { CreateEventRequest } from "../../../generated/models/CreateEventRequest.generated";
 import { AuthUser } from "../../../generated/models/AuthUser.generated";
-import { Params } from "../../../common/parameters/Params";
+import { EventParams } from "../../../common/parameters/Params";
 import { GetEventsResponse } from "../../../generated/models/GetEventsResponse.generated";
 import { Reference } from "../../../generated/models/Reference.generated";
 import { Event } from "../../../generated/models/Event.generated";
@@ -32,7 +32,7 @@ const log: debug.IDebugger = debug("app:events-controller");
 export class EventsController implements ResourcePermissionController {
 	constructor(public eventsService: EventsService) {}
 
-	async listEvents(res: express.Response, pagination: Pagination, params?: Params) {
+	async listEvents(res: express.Response, pagination: Pagination, params?: EventParams) {
 		const filter: Filter = this.getEventsFilter(params);
 		const totalCount = await this.eventsService.countEvents(filter);
 
@@ -333,7 +333,7 @@ export class EventsController implements ResourcePermissionController {
 			: {};
 	}
 
-	private getEventsFilter(params?: Params): Filter {
+	private getEventsFilter(params?: EventParams): Filter {
 		const filter: Filter = {
 			...this.getOrganizedByFilter(params?.organizedBy),
 			...getEditableByFilter(params?.editableBy),

--- a/src/resources/events/controllers/EventsController.ts
+++ b/src/resources/events/controllers/EventsController.ts
@@ -61,6 +61,8 @@ export class EventsController implements ResourcePermissionController {
 		const totalCount = await this.eventsService.countEvents(filter);
 
 		const sendEventsResponse = (data: { events?: Event[]; eventsReferences?: Reference[] }) => {
+			console.log("data", data);
+
 			res.status(200).send(
 				new SuccessResponseBuilder<GetEventsResponse>()
 					.okResponse({

--- a/src/resources/events/controllers/EventsController.ts
+++ b/src/resources/events/controllers/EventsController.ts
@@ -1,6 +1,6 @@
 import debug from "debug";
 import express from "express";
-import { Service } from "typedi";
+import { Inject, Service } from "typedi";
 import { Pagination } from "../../../common/parameters/Pagination";
 import { ErrorResponseBuilder, SuccessResponseBuilder } from "../../../common/responses/SuccessResponseBuilder";
 import { AddEventAttractionRequest } from "../../../generated/models/AddEventAttractionRequest.generated";
@@ -25,15 +25,20 @@ import { GetEventsResponse } from "../../../generated/models/GetEventsResponse.g
 import { Reference } from "../../../generated/models/Reference.generated";
 import { Event } from "../../../generated/models/Event.generated";
 import { getEditableByFilter } from "../../../utils/MetadataUtil";
+import { FilterFactory } from "../../../common/filter/FilterFactory";
 
 const log: debug.IDebugger = debug("app:events-controller");
 
 @Service()
 export class EventsController implements ResourcePermissionController {
-	constructor(public eventsService: EventsService) {}
+	constructor(
+		public eventsService: EventsService,
+		@Inject("FilterFactory") public filterFactory: FilterFactory,
+	) {}
 
 	async listEvents(res: express.Response, pagination: Pagination, params?: EventParams) {
 		const filter: Filter = this.getEventsFilter(params);
+
 		const totalCount = await this.eventsService.countEvents(filter);
 
 		const sendEventsResponse = (data: { events?: Event[]; eventsReferences?: Reference[] }) => {

--- a/src/resources/events/services/EventsService.ts
+++ b/src/resources/events/services/EventsService.ts
@@ -17,6 +17,7 @@ import { EventsRepository } from "../repositories/EventsRepository";
 import { AuthUser } from "../../../generated/models/AuthUser.generated";
 import { isSuperAdmin } from "../../auth/middleware/PermissionFlag";
 import { CreateEventRequest } from "../../../generated/models/CreateEventRequest.generated";
+import { log } from "winston";
 
 @Service()
 export class EventsService {
@@ -36,6 +37,8 @@ export class EventsService {
 		searchEventsRequest: SearchEventsRequest,
 		pagination?: Pagination,
 	): Promise<{ events: Event[]; pagination?: Pagination; totalCount: number }> {
+		console.log(this.filterStrategies);
+		
 		if (!this.filterStrategies) {
 			this.filterStrategies = Container.getMany(EventFilterStrategyToken);
 		}

--- a/src/resources/locations/LocationsRoutes.ts
+++ b/src/resources/locations/LocationsRoutes.ts
@@ -12,7 +12,7 @@ import { LocationsController } from "./controllers/LocationsController";
 import { Permit } from "../auth/middleware/Permit";
 import { AuthUser } from "../../generated/models/AuthUser.generated";
 import { CreateLocationRequest } from "../../generated/models/CreateLocationRequest.generated";
-import { Params } from "../../common/parameters/Params";
+import { LocationParams } from "../../common/parameters/Params";
 
 const log: debug.IDebugger = debug("app:locations-routes");
 
@@ -28,7 +28,7 @@ export class LocationsRoutes {
 		router
 			.get(LocationsRoutes.basePath + "/", (req: express.Request, res: express.Response) => {
 				const pagination: Pagination = getPagination(req);
-				const params: Params = {
+				const params: LocationParams = {
 					asReference: req.query.asReference as string,
 					managedBy: req.query.managedBy as string,
 					editableBy: req.query.editableBy as string,

--- a/src/resources/locations/LocationsRoutes.ts
+++ b/src/resources/locations/LocationsRoutes.ts
@@ -7,7 +7,7 @@ import { ClaimLocationRequest } from "../../generated/models/ClaimLocationReques
 import { SearchLocationsRequest } from "../../generated/models/SearchLocationsRequest.generated";
 import { SetLocationManagerRequest } from "../../generated/models/SetLocationManagerRequest.generated";
 import { UpdateLocationRequest } from "../../generated/models/UpdateLocationRequest.generated";
-import { getPagination } from "../../utils/RequestUtil";
+import { extractArrayQueryParam, getPagination } from "../../utils/RequestUtil";
 import { LocationsController } from "./controllers/LocationsController";
 import { Permit } from "../auth/middleware/Permit";
 import { AuthUser } from "../../generated/models/AuthUser.generated";
@@ -28,10 +28,14 @@ export class LocationsRoutes {
 		router
 			.get(LocationsRoutes.basePath + "/", (req: express.Request, res: express.Response) => {
 				const pagination: Pagination = getPagination(req);
+				const anyAccessibilities: string[] | undefined = extractArrayQueryParam(req, "anyAccessibilities");
+				const allAccessibilities: string[] | undefined = extractArrayQueryParam(req, "allAccessibilities");
 				const params: LocationParams = {
 					asReference: req.query.asReference as string,
 					managedBy: req.query.managedBy as string,
 					editableBy: req.query.editableBy as string,
+					anyAccessibilities: anyAccessibilities,
+					allAccessibilities: allAccessibilities,
 				};
 
 				this.locationsController.listLocations(res, pagination, params);

--- a/src/resources/locations/controllers/LocationsController.ts
+++ b/src/resources/locations/controllers/LocationsController.ts
@@ -28,7 +28,7 @@ const log: debug.IDebugger = debug("app:locations-controller");
 export class LocationsController implements ResourcePermissionController {
 	constructor(
 		public locationsService: LocationsService,
-		@Inject("AttractionFilterFactory") public filterFactory: FilterFactory<Location>,
+		@Inject("FilterFactory") public filterFactory: FilterFactory,
 	) {}
 
 	async listLocations(res: express.Response, pagination: Pagination, params?: LocationParams) {

--- a/src/resources/locations/controllers/LocationsController.ts
+++ b/src/resources/locations/controllers/LocationsController.ts
@@ -13,7 +13,6 @@ import { UpdateLocationRequest } from "../../../generated/models/UpdateLocationR
 import { LocationsService } from "../services/LocationsService";
 import { Filter } from "../../../generated/models/Filter.generated";
 import { ResourcePermissionController } from "../../auth/controllers/ResourcePermissionController";
-import { GetLocationsResponse } from "../../../generated/models/GetLocationsResponse.generated";
 import { GetLocationResponse } from "../../../generated/models/GetLocationResponse.generated";
 import { CreateLocationResponse } from "../../../generated/models/CreateLocationResponse.generated";
 import { AuthUser } from "../../../generated/models/AuthUser.generated";
@@ -21,6 +20,7 @@ import { CreateLocationRequest } from "../../../generated/models/CreateLocationR
 import { LocationParams } from "../../../common/parameters/Params";
 import { getEditableByFilter } from "../../../utils/MetadataUtil";
 import { FilterFactory } from "../../../common/filter/FilterFactory";
+import { GetLocationsResponse } from "../../../generated/models/GetLocationsResponse.generated";
 
 const log: debug.IDebugger = debug("app:locations-controller");
 

--- a/src/resources/locations/controllers/LocationsController.ts
+++ b/src/resources/locations/controllers/LocationsController.ts
@@ -18,7 +18,7 @@ import { GetLocationResponse } from "../../../generated/models/GetLocationRespon
 import { CreateLocationResponse } from "../../../generated/models/CreateLocationResponse.generated";
 import { AuthUser } from "../../../generated/models/AuthUser.generated";
 import { CreateLocationRequest } from "../../../generated/models/CreateLocationRequest.generated";
-import { Params } from "../../../common/parameters/Params";
+import { LocationParams } from "../../../common/parameters/Params";
 import { getEditableByFilter } from "../../../utils/MetadataUtil";
 
 const log: debug.IDebugger = debug("app:locations-controller");
@@ -27,7 +27,7 @@ const log: debug.IDebugger = debug("app:locations-controller");
 export class LocationsController implements ResourcePermissionController {
 	constructor(public locationsService: LocationsService) {}
 
-	async listLocations(res: express.Response, pagination: Pagination, params?: Params) {
+	async listLocations(res: express.Response, pagination: Pagination, params?: LocationParams) {
 		const filter: Filter = this.getLocationsFilter(params);
 		const totalCount = await this.locationsService.countLocations(filter);
 
@@ -238,7 +238,7 @@ export class LocationsController implements ResourcePermissionController {
 		return managedBy ? { "manager.referenceId": managedBy } : undefined;
 	}
 
-	private getLocationsFilter(params?: Params): Filter {
+	private getLocationsFilter(params?: LocationParams): Filter {
 		const filter: Filter = {
 			...this.getManagedByFilter(params?.managedBy),
 			...getEditableByFilter(params?.editableBy),

--- a/src/resources/organizations/OrganizationsRoutes.ts
+++ b/src/resources/organizations/OrganizationsRoutes.ts
@@ -11,7 +11,7 @@ import { getPagination } from "../../utils/RequestUtil";
 import { Permit } from "../auth/middleware/Permit";
 import { OrganizationsController } from "./controllers/OrganizationsController";
 import { AuthUser } from "../../generated/models/AuthUser.generated";
-import { Params } from "../../common/parameters/Params";
+import { OrganizationParams } from "../../common/parameters/Params";
 
 @Service()
 export class OrganizationsRoutes {
@@ -25,7 +25,7 @@ export class OrganizationsRoutes {
 		router
 			.get(OrganizationsRoutes.basePath + "/", (req: express.Request, res: express.Response) => {
 				const pagination: Pagination = getPagination(req);
-				const params: Params = {
+				const params: OrganizationParams = {
 					asReference: req.query.asReference as string,
 					editableBy: req.query.editableBy as string,
 				};

--- a/src/resources/organizations/controllers/OrganizationsController.ts
+++ b/src/resources/organizations/controllers/OrganizationsController.ts
@@ -22,7 +22,7 @@ import { GetOrganizationMembershipsResponse } from "../../../generated/models/Ge
 import { UpdateOrganizationMembershipRequest } from "../../../generated/models/UpdateOrganizationMembershipRequest.generated";
 import { GetOrganizationMembershipResponse } from "../../../generated/models/GetOrganizationMembershipResponse.generated";
 import { AuthUser } from "../../../generated/models/AuthUser.generated";
-import { Params } from "../../../common/parameters/Params";
+import { OrganizationParams } from "../../../common/parameters/Params";
 import { Organization } from "../../../generated/models/Organization.generated";
 import { getEditableByFilter } from "../../../utils/MetadataUtil";
 
@@ -35,7 +35,7 @@ export class OrganizationsController implements ResourcePermissionController {
 		public userService: UsersService,
 	) {}
 
-	async listOrganizations(res: express.Response, pagination: Pagination, params?: Params) {
+	async listOrganizations(res: express.Response, pagination: Pagination, params?: OrganizationParams) {
 		const filter: Filter = this.getOrganizationsFilter(params);
 		const totalCount = await this.organizationsService.countOrganizations(filter);
 
@@ -340,7 +340,7 @@ export class OrganizationsController implements ResourcePermissionController {
 		}
 	}
 
-	private getOrganizationsFilter(params?: Params): Filter {
+	private getOrganizationsFilter(params?: OrganizationParams): Filter {
 		const filter: Filter = {
 			...getEditableByFilter(params?.editableBy),
 		};

--- a/src/resources/organizations/controllers/OrganizationsController.ts
+++ b/src/resources/organizations/controllers/OrganizationsController.ts
@@ -1,6 +1,6 @@
 import debug from "debug";
 import express from "express";
-import { Service } from "typedi";
+import { Inject, Service } from "typedi";
 import { Pagination } from "../../../common/parameters/Pagination";
 import { ErrorResponseBuilder, SuccessResponseBuilder } from "../../../common/responses/SuccessResponseBuilder";
 import { CreateOrganizationRequest } from "../../../generated/models/CreateOrganizationRequest.generated";
@@ -25,6 +25,7 @@ import { AuthUser } from "../../../generated/models/AuthUser.generated";
 import { OrganizationParams } from "../../../common/parameters/Params";
 import { Organization } from "../../../generated/models/Organization.generated";
 import { getEditableByFilter } from "../../../utils/MetadataUtil";
+import { FilterFactory } from "../../../common/filter/FilterFactory";
 
 const log: debug.IDebugger = debug("app:organizations-controller");
 
@@ -33,6 +34,7 @@ export class OrganizationsController implements ResourcePermissionController {
 	constructor(
 		public organizationsService: OrganizationsService,
 		public userService: UsersService,
+		@Inject("FilterFactory") public filterFactory: FilterFactory,
 	) {}
 
 	async listOrganizations(res: express.Response, pagination: Pagination, params?: OrganizationParams) {

--- a/src/schemas/kulturdaten.berlin.openapi.base.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.base.yml
@@ -98,9 +98,10 @@ paths:
             type: string
         - name: withEvents
           description:
-            Specifies whether to include a list of related events for each attraction in the response. 
-            When set to true, the response will contain an additional field listing events associated with each attraction. 
-            If false or omitted, the response includes only the attractions without their related events.
+            Specifies whether to include a list of all related events in the response. 
+            When set to true, the response will contain an additional property `related`, 
+            under which all events associated with the attractions are listed in an array under `related.events`. 
+            If true, the maximum PageSize is 30.
           in: query
           required: false
           example: false
@@ -1847,7 +1848,7 @@ components:
         type: number
     pageSize:
       name: pageSize
-      description: Default value is 30. Max value is 500. 
+      description: Default value is 30. Maximum value is 500 for normal queries. 30 for more complex queries.
       in: query
       required: false
       example: 30

--- a/src/schemas/kulturdaten.berlin.openapi.base.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.base.yml
@@ -243,6 +243,16 @@ paths:
           schema:
             type: string
         - $ref: "#/components/parameters/asReference"
+        - name: withEvents
+          description:
+            Specifies whether to include a list of all related events in the response. 
+            When set to true, the response will contain an additional property `related`, 
+            under which all events associated with the attraction are listed in an array under `related.events`. 
+          in: query
+          required: false
+          example: false
+          schema:
+            type: boolean
       responses:
         "200":
           description: OK

--- a/src/schemas/kulturdaten.berlin.openapi.base.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.base.yml
@@ -384,7 +384,7 @@ paths:
         - name: inFuture
           in: query
           required: false
-          description: |
+          description: 
             Filters the events based on their occurrence in the future.
             When set to true, returns only events that are scheduled to occur in the future.
             When set to false, returns events regardless of their scheduled date.
@@ -434,7 +434,7 @@ paths:
         - name: isFreeOfCharge
           in: query
           required: false
-          description: |
+          description: 
             Filters the events based on the admission charge. 
             When set to true, returns only the events that are free of charge. 
             When set to false, returns events regardless of their admission charge status.

--- a/src/schemas/kulturdaten.berlin.openapi.base.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.base.yml
@@ -398,7 +398,11 @@ paths:
         - name: isFreeOfCharge
           in: query
           required: false
-          description: Returns only the events that are free of charge
+          description: |
+            Filters the events based on the admission charge. 
+            When set to true, returns only the events that are free of charge. 
+            When set to false, returns only the events that are not free of charge. 
+            If not provided, all events are returned irrespective of their admission charge status.
           schema:
             type: boolean
            

--- a/src/schemas/kulturdaten.berlin.openapi.base.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.base.yml
@@ -96,6 +96,16 @@ paths:
           description: Returns only the Attractions editable by the entered Organization-ID
           schema:
             type: string
+        - name: withEvents
+          description: |
+            Specifies whether to include a list of related events for each attraction in the response. 
+            When set to true, the response will contain an additional field listing events associated with each attraction. 
+            If false or omitted, the response includes only the attractions without their related events.
+          in: query
+          required: false
+          example: false
+          schema:
+            type: boolean
       responses:
         "200":
           description: OK

--- a/src/schemas/kulturdaten.berlin.openapi.base.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.base.yml
@@ -395,6 +395,12 @@ paths:
           description: Returns only the events that include the specified Attraction-ID
           schema:
             type: string
+        - name: isFreeOfCharge
+          in: query
+          required: false
+          description: Returns only the events that are free of charge
+          schema:
+            type: boolean
            
       responses:
         "200":

--- a/src/schemas/kulturdaten.berlin.openapi.base.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.base.yml
@@ -378,10 +378,25 @@ paths:
             Filters the events based on their occurrence in the future.
             When set to true, returns only events that are scheduled to occur in the future.
             When set to false, returns events regardless of their scheduled date.
-            If not provided, the default behavior is to return only events in the future.
           schema:
             type: boolean
             default: true
+        - name: startDate
+          in: query
+          required: false
+          description: The start date of the range for filtering events. Events on or after this date will be included. The date should be in YYYY-MM-DD format.
+          schema:
+            type: string
+            format: date
+            example: "2023-01-01"
+        - name: endDate
+          in: query
+          required: false
+          description: The end date of the range for filtering events. Events on or before this date will be included. The date should be in YYYY-MM-DD format.
+          schema:
+            type: string
+            format: date
+            example: "2023-12-31"
         - name: organizedBy
           in: query
           required: false

--- a/src/schemas/kulturdaten.berlin.openapi.base.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.base.yml
@@ -96,10 +96,20 @@ paths:
           description: Returns only the Attractions editable by the entered Organization-ID
           schema:
             type: string
-        - name: tags
+        - name: anyTags
           in: query
           required: false
           description: Returns only the Attractions that match any of the specified tags
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+        - name: allTags
+          in: query
+          required: false
+          description: Returns only the Attractions that match all of the specified tags
           schema:
             type: array
             items:

--- a/src/schemas/kulturdaten.berlin.openapi.base.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.base.yml
@@ -371,6 +371,17 @@ paths:
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/asReference"
+        - name: inFuture
+          in: query
+          required: false
+          description: |
+            Filters the events based on their occurrence in the future.
+            When set to true, returns only events that are scheduled to occur in the future.
+            When set to false, returns events regardless of their scheduled date.
+            If not provided, the default behavior is to return only events in the future.
+          schema:
+            type: boolean
+            default: true
         - name: organizedBy
           in: query
           required: false
@@ -401,7 +412,7 @@ paths:
           description: |
             Filters the events based on the admission charge. 
             When set to true, returns only the events that are free of charge. 
-            When set to false, returns only the events that are not free of charge. 
+            When set to false, returns events regardless of their admission charge status.
             If not provided, all events are returned irrespective of their admission charge status.
           schema:
             type: boolean

--- a/src/schemas/kulturdaten.berlin.openapi.base.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.base.yml
@@ -96,6 +96,16 @@ paths:
           description: Returns only the Attractions editable by the entered Organization-ID
           schema:
             type: string
+        - name: tags
+          in: query
+          required: false
+          description: Returns only the Attractions that match any of the specified tags
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
       responses:
         "200":
           description: OK

--- a/src/schemas/kulturdaten.berlin.openapi.base.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.base.yml
@@ -780,6 +780,26 @@ paths:
           description: Returns only the locations editable by the entered Organization-ID
           schema:
             type: string
+        - name: anyAccessibilities
+          in: query
+          required: false
+          description: Returns only the Locations that match any of the specified accessibility tags
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+        - name: allAccessibilities
+          in: query
+          required: false
+          description: Returns only the Locations that match all of the specified accessibility tags
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
       responses:
         "200":
           description: OK
@@ -1781,7 +1801,7 @@ components:
         type: number
     pageSize:
       name: pageSize
-      description: Default value is 30
+      description: Default value is 30. Max value is 500. 
       in: query
       required: false
       example: 30

--- a/src/schemas/kulturdaten.berlin.openapi.generated.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.generated.yml
@@ -131,20 +131,37 @@ paths:
           schema:
             type: string
         - name: withEvents
-          description: >
+          description: >-
             Specifies whether to include a list of related events for each
-            attraction in the response. 
-
-            When set to true, the response will contain an additional field
-            listing events associated with each attraction. 
-
-            If false or omitted, the response includes only the attractions
-            without their related events.
+            attraction in the response. When set to true, the response will
+            contain an additional field listing events associated with each
+            attraction. If false or omitted, the response includes only the
+            attractions without their related events.
           in: query
           required: false
           example: false
           schema:
             type: boolean
+        - name: anyTags
+          in: query
+          required: false
+          description: Returns only the Attractions that match any of the specified tags
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+        - name: allTags
+          in: query
+          required: false
+          description: Returns only the Attractions that match all of the specified tags
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
       responses:
         "200":
           description: OK
@@ -405,6 +422,40 @@ paths:
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/asReference"
+        - name: inFuture
+          in: query
+          required: false
+          description: >
+            Filters the events based on their occurrence in the future.
+
+            When set to true, returns only events that are scheduled to occur in
+            the future.
+
+            When set to false, returns events regardless of their scheduled
+            date.
+          schema:
+            type: boolean
+            default: true
+        - name: startDate
+          in: query
+          required: false
+          description: >-
+            The start date of the range for filtering events. Events on or after
+            this date will be included. The date should be in YYYY-MM-DD format.
+          schema:
+            type: string
+            format: date
+            example: "2023-01-01"
+        - name: endDate
+          in: query
+          required: false
+          description: >-
+            The end date of the range for filtering events. Events on or before
+            this date will be included. The date should be in YYYY-MM-DD format.
+          schema:
+            type: string
+            format: date
+            example: "2023-12-31"
         - name: organizedBy
           in: query
           required: false
@@ -429,6 +480,21 @@ paths:
           description: Returns only the events that include the specified Attraction-ID
           schema:
             type: string
+        - name: isFreeOfCharge
+          in: query
+          required: false
+          description: >
+            Filters the events based on the admission charge. 
+
+            When set to true, returns only the events that are free of charge. 
+
+            When set to false, returns events regardless of their admission
+            charge status.
+
+            If not provided, all events are returned irrespective of their
+            admission charge status.
+          schema:
+            type: boolean
       responses:
         "200":
           description: OK
@@ -795,6 +861,30 @@ paths:
           description: Returns only the locations editable by the entered Organization-ID
           schema:
             type: string
+        - name: anyAccessibilities
+          in: query
+          required: false
+          description: >-
+            Returns only the Locations that match any of the specified
+            accessibility tags
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+        - name: allAccessibilities
+          in: query
+          required: false
+          description: >-
+            Returns only the Locations that match all of the specified
+            accessibility tags
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
       responses:
         "200":
           description: OK
@@ -1756,7 +1846,7 @@ components:
         type: number
     pageSize:
       name: pageSize
-      description: Default value is 30
+      description: Default value is 30. Max value is 500.
       in: query
       required: false
       example: 30

--- a/src/schemas/kulturdaten.berlin.openapi.generated.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.generated.yml
@@ -132,11 +132,11 @@ paths:
             type: string
         - name: withEvents
           description: >-
-            Specifies whether to include a list of related events for each
-            attraction in the response. When set to true, the response will
-            contain an additional field listing events associated with each
-            attraction. If false or omitted, the response includes only the
-            attractions without their related events.
+            Specifies whether to include a list of all related events in the
+            response. When set to true, the response will contain an additional
+            property `related`, under which all events associated with the
+            attractions are listed in an array under `related.events`. If true,
+            the maximum PageSize is 30.
           in: query
           required: false
           example: false
@@ -289,6 +289,17 @@ paths:
           schema:
             type: string
         - $ref: "#/components/parameters/asReference"
+        - name: withEvents
+          description: >-
+            Specifies whether to include a list of all related events in the
+            response. When set to true, the response will contain an additional
+            property `related`, under which all events associated with the
+            attraction are listed in an array under `related.events`.
+          in: query
+          required: false
+          example: false
+          schema:
+            type: boolean
       responses:
         "200":
           description: OK
@@ -1839,7 +1850,9 @@ components:
         type: number
     pageSize:
       name: pageSize
-      description: Default value is 30. Max value is 500.
+      description: >-
+        Default value is 30. Maximum value is 500 for normal queries. 30 for
+        more complex queries.
       in: query
       required: false
       example: 30

--- a/src/schemas/kulturdaten.berlin.openapi.generated.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.generated.yml
@@ -437,7 +437,16 @@ paths:
         - name: isFreeOfCharge
           in: query
           required: false
-          description: Returns only the events that are free of charge
+          description: >
+            Filters the events based on the admission charge. 
+
+            When set to true, returns only the events that are free of charge. 
+
+            When set to false, returns only the events that are not free of
+            charge. 
+
+            If not provided, all events are returned irrespective of their
+            admission charge status.
           schema:
             type: boolean
       responses:

--- a/src/schemas/kulturdaten.berlin.openapi.generated.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.generated.yml
@@ -1886,6 +1886,8 @@ components:
             details:
               type: string
           additionalProperties: false
+        related:
+          type: object
       required:
         - success
       additionalProperties: false
@@ -1908,6 +1910,8 @@ components:
             details:
               type: string
           additionalProperties: false
+        related:
+          type: object
       required:
         - success
       additionalProperties: false
@@ -1930,6 +1934,8 @@ components:
             details:
               type: string
           additionalProperties: false
+        related:
+          type: object
       required:
         - success
       additionalProperties: false
@@ -4524,458 +4530,306 @@ components:
                       - referenceType
                       - referenceId
                     additionalProperties: false
-                attractionsWithEvents:
-                  type: array
-                  items:
+        related:
+          type: object
+          properties:
+            events:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    enum:
+                      - type.Event
+                  identifier:
+                    type: string
+                  metadata:
                     type: object
                     properties:
-                      attraction:
-                        type: object
-                        properties:
-                          type:
-                            type: string
-                            enum:
-                              - type.Attraction
-                          identifier:
-                            type: string
-                          metadata:
-                            type: object
-                            properties:
-                              created:
-                                type: string
-                                description: >-
-                                  The date and time the object was created (ISO
-                                  timestamp).
-                                example: "2011-10-05T14:48:00.000Z"
-                              updated:
-                                type: string
-                                description: >-
-                                  The date and time the object was last updated
-                                  (ISO timestamp). Is identical to created date
-                                  after first creation.
-                                example: "2011-10-05T14:48:00.000Z"
-                              origin:
-                                type: string
-                                description: The source of this object.
-                                example: bezirkskalender
-                              originObjectID:
-                                type: string
-                                description: >-
-                                  The original ID of this object in the original
-                                  system.
-                              availableLanguages:
-                                type: array
-                                description: List of languages this object is available in.
-                                example:
-                                  - de
-                                  - en
-                                items:
-                                  type: string
-                              externalIDs:
-                                type: object
-                                additionalProperties:
-                                  type: string
-                              editableBy:
-                                type: array
-                                description: >-
-                                  List of organizations that can edit this
-                                  object.
-                                items:
-                                  type: string
-                            required:
-                              - created
-                              - updated
-                            additionalProperties: false
-                          status:
-                            type: string
-                            enum:
-                              - attraction.published
-                              - attraction.unpublished
-                              - attraction.archived
-                          title:
-                            type: object
-                            additionalProperties:
-                              type: string
-                            description: The main title of the attraction.
-                            example:
-                              de: Konzert
-                              en: concert
-                          description:
-                            type: object
-                            additionalProperties:
-                              type: string
-                            description: >-
-                              A string that can be translated into multiple
-                              languages, e.g. { "de": "Konzert", "en": "concert"
-                              }
-                            example:
-                              de: Eine Beschreibung
-                              en: Some description
-                          pleaseNote:
-                            type: object
-                            additionalProperties:
-                              type: string
-                            description: >-
-                              Any important information for the attendees of the
-                              attraction.
-                            example:
-                              de: Achtung, laute Geräusche
-                              en: Warning, loud noises
-                          website:
-                            type: string
-                            example: https://example.com/
-                          curator:
-                            type: object
-                            properties:
-                              referenceType:
-                                type: string
-                              referenceId:
-                                type: string
-                              referenceLabel:
-                                type: object
-                                additionalProperties:
-                                  type: string
-                                description: >-
-                                  A string that can be translated into multiple
-                                  languages, e.g. { "de": "Konzert", "en":
-                                  "concert" }
-                                example:
-                                  de: Konzert
-                                  en: concert
-                            required:
-                              - referenceType
-                              - referenceId
-                            additionalProperties: false
-                            description: The curating organization of this attraction.
-                          inLanguages:
-                            type: array
-                            description: List of languages this object is available in.
-                            example:
-                              - de
-                              - en
-                            items:
-                              type: string
-                          tags:
-                            type: array
-                            description: List of tags for this attraction.
-                            items:
-                              type: string
-                          externalLinks:
-                            type: array
-                            description: >-
-                              Links to external resources related to this
-                              object.
-                            items:
-                              type: object
-                              properties:
-                                displayName:
-                                  type: string
-                                  example: Website
-                                url:
-                                  type: string
-                                  example: https://example.com/
-                              required:
-                                - url
-                              additionalProperties: false
-                        required:
-                          - type
-                          - identifier
-                          - metadata
-                          - status
-                          - title
-                      events:
+                      created:
+                        type: string
+                        description: >-
+                          The date and time the object was created (ISO
+                          timestamp).
+                        example: "2011-10-05T14:48:00.000Z"
+                      updated:
+                        type: string
+                        description: >-
+                          The date and time the object was last updated (ISO
+                          timestamp). Is identical to created date after first
+                          creation.
+                        example: "2011-10-05T14:48:00.000Z"
+                      origin:
+                        type: string
+                        description: The source of this object.
+                        example: bezirkskalender
+                      originObjectID:
+                        type: string
+                        description: The original ID of this object in the original system.
+                      availableLanguages:
                         type: array
+                        description: List of languages this object is available in.
+                        example:
+                          - de
+                          - en
                         items:
+                          type: string
+                      externalIDs:
+                        type: object
+                        additionalProperties:
+                          type: string
+                      editableBy:
+                        type: array
+                        description: List of organizations that can edit this object.
+                        items:
+                          type: string
+                    required:
+                      - created
+                      - updated
+                    additionalProperties: false
+                  status:
+                    type: string
+                    enum:
+                      - event.published
+                      - event.unpublished
+                      - event.archived
+                  scheduleStatus:
+                    type: string
+                    enum:
+                      - event.cancelled
+                      - event.postponed
+                      - event.rescheduled
+                      - event.scheduled
+                  schedule:
+                    type: object
+                    properties:
+                      startDate:
+                        type: string
+                        description: >-
+                          The date (year, month, day) the event starts, in
+                          timezone Europe/Berlin.
+                        example: "2023-09-08"
+                      startTime:
+                        type: string
+                        description: The time the event starts, in timezone Europe/Berlin.
+                        example: "20:00:00"
+                      permanentOpening:
+                        type: boolean
+                        description: >-
+                          Indicates whether the event is permanently open (and
+                          has no end date/time).
+                        example: false
+                      doorTime:
+                        type: string
+                        description: >-
+                          The time that guests can enter the venue, in timezone
+                          Europe/Berlin.
+                        example: "19:00:00"
+                      endDate:
+                        type: string
+                        description: >-
+                          The date (year, month, day) the event ends, in
+                          timezone Europe/Berlin.
+                        example: "2023-09-08"
+                      endTime:
+                        type: string
+                        description: The time the event end, in timezone Europe/Berlin.
+                        example: "22:00"
+                    required:
+                      - startDate
+                      - startTime
+                    additionalProperties: false
+                  title:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    description: >-
+                      A string that can be translated into multiple languages,
+                      e.g. { "de": "Konzert", "en": "concert" }
+                    example:
+                      de: Konzert
+                      en: concert
+                  description:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    description: >-
+                      A string that can be translated into multiple languages,
+                      e.g. { "de": "Konzert", "en": "concert" }
+                    example:
+                      de: Konzert
+                      en: concert
+                  pleaseNote:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    description: >-
+                      A string that can be translated into multiple languages,
+                      e.g. { "de": "Konzert", "en": "concert" }
+                    example:
+                      de: Konzert
+                      en: concert
+                  website:
+                    type: string
+                    example: https://example.com/
+                  inLanguages:
+                    type: array
+                    description: List of languages this object is available in.
+                    example:
+                      - de
+                      - en
+                    items:
+                      type: string
+                  tags:
+                    type: array
+                    items:
+                      type: string
+                  locations:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        referenceType:
+                          type: string
+                        referenceId:
+                          type: string
+                        referenceLabel:
                           type: object
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                - type.Event
-                            identifier:
-                              type: string
-                            metadata:
-                              type: object
-                              properties:
-                                created:
-                                  type: string
-                                  description: >-
-                                    The date and time the object was created
-                                    (ISO timestamp).
-                                  example: "2011-10-05T14:48:00.000Z"
-                                updated:
-                                  type: string
-                                  description: >-
-                                    The date and time the object was last
-                                    updated (ISO timestamp). Is identical to
-                                    created date after first creation.
-                                  example: "2011-10-05T14:48:00.000Z"
-                                origin:
-                                  type: string
-                                  description: The source of this object.
-                                  example: bezirkskalender
-                                originObjectID:
-                                  type: string
-                                  description: >-
-                                    The original ID of this object in the
-                                    original system.
-                                availableLanguages:
-                                  type: array
-                                  description: >-
-                                    List of languages this object is available
-                                    in.
-                                  example:
-                                    - de
-                                    - en
-                                  items:
-                                    type: string
-                                externalIDs:
-                                  type: object
-                                  additionalProperties:
-                                    type: string
-                                editableBy:
-                                  type: array
-                                  description: >-
-                                    List of organizations that can edit this
-                                    object.
-                                  items:
-                                    type: string
-                              required:
-                                - created
-                                - updated
-                              additionalProperties: false
-                            status:
-                              type: string
-                              enum:
-                                - event.published
-                                - event.unpublished
-                                - event.archived
-                            scheduleStatus:
-                              type: string
-                              enum:
-                                - event.cancelled
-                                - event.postponed
-                                - event.rescheduled
-                                - event.scheduled
-                            schedule:
-                              type: object
-                              properties:
-                                startDate:
-                                  type: string
-                                  description: >-
-                                    The date (year, month, day) the event
-                                    starts, in timezone Europe/Berlin.
-                                  example: "2023-09-08"
-                                startTime:
-                                  type: string
-                                  description: >-
-                                    The time the event starts, in timezone
-                                    Europe/Berlin.
-                                  example: "20:00:00"
-                                permanentOpening:
-                                  type: boolean
-                                  description: >-
-                                    Indicates whether the event is permanently
-                                    open (and has no end date/time).
-                                  example: false
-                                doorTime:
-                                  type: string
-                                  description: >-
-                                    The time that guests can enter the venue, in
-                                    timezone Europe/Berlin.
-                                  example: "19:00:00"
-                                endDate:
-                                  type: string
-                                  description: >-
-                                    The date (year, month, day) the event ends,
-                                    in timezone Europe/Berlin.
-                                  example: "2023-09-08"
-                                endTime:
-                                  type: string
-                                  description: >-
-                                    The time the event end, in timezone
-                                    Europe/Berlin.
-                                  example: "22:00"
-                              required:
-                                - startDate
-                                - startTime
-                              additionalProperties: false
-                            title:
-                              type: object
-                              additionalProperties:
-                                type: string
-                              description: >-
-                                A string that can be translated into multiple
-                                languages, e.g. { "de": "Konzert", "en":
-                                "concert" }
-                              example:
-                                de: Konzert
-                                en: concert
-                            description:
-                              type: object
-                              additionalProperties:
-                                type: string
-                              description: >-
-                                A string that can be translated into multiple
-                                languages, e.g. { "de": "Konzert", "en":
-                                "concert" }
-                              example:
-                                de: Konzert
-                                en: concert
-                            pleaseNote:
-                              type: object
-                              additionalProperties:
-                                type: string
-                              description: >-
-                                A string that can be translated into multiple
-                                languages, e.g. { "de": "Konzert", "en":
-                                "concert" }
-                              example:
-                                de: Konzert
-                                en: concert
-                            website:
-                              type: string
-                              example: https://example.com/
-                            inLanguages:
-                              type: array
-                              description: List of languages this object is available in.
-                              example:
-                                - de
-                                - en
-                              items:
-                                type: string
-                            tags:
-                              type: array
-                              items:
-                                type: string
-                            locations:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  referenceType:
-                                    type: string
-                                  referenceId:
-                                    type: string
-                                  referenceLabel:
-                                    type: object
-                                    additionalProperties:
-                                      type: string
-                                    description: >-
-                                      A string that can be translated into
-                                      multiple languages, e.g. { "de":
-                                      "Konzert", "en": "concert" }
-                                    example:
-                                      de: Konzert
-                                      en: concert
-                                required:
-                                  - referenceType
-                                  - referenceId
-                                additionalProperties: false
-                            attractions:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  referenceType:
-                                    type: string
-                                  referenceId:
-                                    type: string
-                                  referenceLabel:
-                                    type: object
-                                    additionalProperties:
-                                      type: string
-                                    description: >-
-                                      A string that can be translated into
-                                      multiple languages, e.g. { "de":
-                                      "Konzert", "en": "concert" }
-                                    example:
-                                      de: Konzert
-                                      en: concert
-                                required:
-                                  - referenceType
-                                  - referenceId
-                                additionalProperties: false
-                            organizer:
-                              type: object
-                              properties:
-                                referenceType:
-                                  type: string
-                                referenceId:
-                                  type: string
-                                referenceLabel:
-                                  type: object
-                                  additionalProperties:
-                                    type: string
-                                  description: >-
-                                    A string that can be translated into
-                                    multiple languages, e.g. { "de": "Konzert",
-                                    "en": "concert" }
-                                  example:
-                                    de: Konzert
-                                    en: concert
-                              required:
-                                - referenceType
-                                - referenceId
-                              additionalProperties: false
-                            contact:
-                              type: object
-                              description: >-
-                                A person that is connected to and/or responsible
-                                for the referenced entity.
-                              properties:
-                                name:
-                                  type: string
-                                  description: Full name of the contact person.
-                                  example: Jane Doe
-                                email:
-                                  type: string
-                                  description: Email address of the contact person.
-                                  example: someone@example.com
-                                telephone:
-                                  type: string
-                                  description: Phone number of the contact person.
-                                  example: +49 30 12345678
-                              additionalProperties: false
-                            admission:
-                              type: object
-                              description: >-
-                                Information about the admission to the
-                                event/attraction.
-                              properties:
-                                note:
-                                  type: object
-                                  additionalProperties:
-                                    type: string
-                                  description: >-
-                                    A string that can be translated into
-                                    multiple languages, e.g. { "de": "Konzert",
-                                    "en": "concert" }
-                                  example:
-                                    de: Konzert
-                                    en: concert
-                                ticketType:
-                                  type: string
-                                  enum:
-                                    - ticketType.ticketRequired
-                                    - ticketType.freeOfCharge
-                                registrationType:
-                                  type: string
-                                  enum:
-                                    - registrationType.registrationRequired
-                                    - registrationType.noRegistrationRequired
-                                    - registrationType.registrationDesired
-                                admissionLink:
-                                  type: string
-                                  example: https://example.com/
-                              additionalProperties: false
-                          required:
-                            - type
-                            - identifier
-                            - metadata
-                            - status
-                            - scheduleStatus
-                          additionalProperties: false
+                          additionalProperties:
+                            type: string
+                          description: >-
+                            A string that can be translated into multiple
+                            languages, e.g. { "de": "Konzert", "en": "concert" }
+                          example:
+                            de: Konzert
+                            en: concert
+                      required:
+                        - referenceType
+                        - referenceId
+                      additionalProperties: false
+                  attractions:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        referenceType:
+                          type: string
+                        referenceId:
+                          type: string
+                        referenceLabel:
+                          type: object
+                          additionalProperties:
+                            type: string
+                          description: >-
+                            A string that can be translated into multiple
+                            languages, e.g. { "de": "Konzert", "en": "concert" }
+                          example:
+                            de: Konzert
+                            en: concert
+                      required:
+                        - referenceType
+                        - referenceId
+                      additionalProperties: false
+                  organizer:
+                    type: object
+                    properties:
+                      referenceType:
+                        type: string
+                      referenceId:
+                        type: string
+                      referenceLabel:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                    required:
+                      - referenceType
+                      - referenceId
+                    additionalProperties: false
+                  contact:
+                    type: object
+                    description: >-
+                      A person that is connected to and/or responsible for the
+                      referenced entity.
+                    properties:
+                      name:
+                        type: string
+                        description: Full name of the contact person.
+                        example: Jane Doe
+                      email:
+                        type: string
+                        description: Email address of the contact person.
+                        example: someone@example.com
+                      telephone:
+                        type: string
+                        description: Phone number of the contact person.
+                        example: +49 30 12345678
+                    additionalProperties: false
+                  admission:
+                    type: object
+                    description: Information about the admission to the event/attraction.
+                    properties:
+                      note:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                      ticketType:
+                        type: string
+                        enum:
+                          - ticketType.ticketRequired
+                          - ticketType.freeOfCharge
+                      registrationType:
+                        type: string
+                        enum:
+                          - registrationType.registrationRequired
+                          - registrationType.noRegistrationRequired
+                          - registrationType.registrationDesired
+                      admissionLink:
+                        type: string
+                        example: https://example.com/
+                    additionalProperties: false
+                required:
+                  - type
+                  - identifier
+                  - metadata
+                  - status
+                  - scheduleStatus
+                additionalProperties: false
+            eventsReferences:
+              type: array
+              items:
+                type: object
+                properties:
+                  referenceType:
+                    type: string
+                  referenceId:
+                    type: string
+                  referenceLabel:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    description: >-
+                      A string that can be translated into multiple languages,
+                      e.g. { "de": "Konzert", "en": "concert" }
+                    example:
+                      de: Konzert
+                      en: concert
+                required:
+                  - referenceType
+                  - referenceId
+                additionalProperties: false
       required:
         - success
       additionalProperties: false
@@ -5321,458 +5175,306 @@ components:
                       - referenceType
                       - referenceId
                     additionalProperties: false
-                attractionsWithEvents:
-                  type: array
-                  items:
+        related:
+          type: object
+          properties:
+            events:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    enum:
+                      - type.Event
+                  identifier:
+                    type: string
+                  metadata:
                     type: object
                     properties:
-                      attraction:
-                        type: object
-                        properties:
-                          type:
-                            type: string
-                            enum:
-                              - type.Attraction
-                          identifier:
-                            type: string
-                          metadata:
-                            type: object
-                            properties:
-                              created:
-                                type: string
-                                description: >-
-                                  The date and time the object was created (ISO
-                                  timestamp).
-                                example: "2011-10-05T14:48:00.000Z"
-                              updated:
-                                type: string
-                                description: >-
-                                  The date and time the object was last updated
-                                  (ISO timestamp). Is identical to created date
-                                  after first creation.
-                                example: "2011-10-05T14:48:00.000Z"
-                              origin:
-                                type: string
-                                description: The source of this object.
-                                example: bezirkskalender
-                              originObjectID:
-                                type: string
-                                description: >-
-                                  The original ID of this object in the original
-                                  system.
-                              availableLanguages:
-                                type: array
-                                description: List of languages this object is available in.
-                                example:
-                                  - de
-                                  - en
-                                items:
-                                  type: string
-                              externalIDs:
-                                type: object
-                                additionalProperties:
-                                  type: string
-                              editableBy:
-                                type: array
-                                description: >-
-                                  List of organizations that can edit this
-                                  object.
-                                items:
-                                  type: string
-                            required:
-                              - created
-                              - updated
-                            additionalProperties: false
-                          status:
-                            type: string
-                            enum:
-                              - attraction.published
-                              - attraction.unpublished
-                              - attraction.archived
-                          title:
-                            type: object
-                            additionalProperties:
-                              type: string
-                            description: The main title of the attraction.
-                            example:
-                              de: Konzert
-                              en: concert
-                          description:
-                            type: object
-                            additionalProperties:
-                              type: string
-                            description: >-
-                              A string that can be translated into multiple
-                              languages, e.g. { "de": "Konzert", "en": "concert"
-                              }
-                            example:
-                              de: Eine Beschreibung
-                              en: Some description
-                          pleaseNote:
-                            type: object
-                            additionalProperties:
-                              type: string
-                            description: >-
-                              Any important information for the attendees of the
-                              attraction.
-                            example:
-                              de: Achtung, laute Geräusche
-                              en: Warning, loud noises
-                          website:
-                            type: string
-                            example: https://example.com/
-                          curator:
-                            type: object
-                            properties:
-                              referenceType:
-                                type: string
-                              referenceId:
-                                type: string
-                              referenceLabel:
-                                type: object
-                                additionalProperties:
-                                  type: string
-                                description: >-
-                                  A string that can be translated into multiple
-                                  languages, e.g. { "de": "Konzert", "en":
-                                  "concert" }
-                                example:
-                                  de: Konzert
-                                  en: concert
-                            required:
-                              - referenceType
-                              - referenceId
-                            additionalProperties: false
-                            description: The curating organization of this attraction.
-                          inLanguages:
-                            type: array
-                            description: List of languages this object is available in.
-                            example:
-                              - de
-                              - en
-                            items:
-                              type: string
-                          tags:
-                            type: array
-                            description: List of tags for this attraction.
-                            items:
-                              type: string
-                          externalLinks:
-                            type: array
-                            description: >-
-                              Links to external resources related to this
-                              object.
-                            items:
-                              type: object
-                              properties:
-                                displayName:
-                                  type: string
-                                  example: Website
-                                url:
-                                  type: string
-                                  example: https://example.com/
-                              required:
-                                - url
-                              additionalProperties: false
-                        required:
-                          - type
-                          - identifier
-                          - metadata
-                          - status
-                          - title
-                      events:
+                      created:
+                        type: string
+                        description: >-
+                          The date and time the object was created (ISO
+                          timestamp).
+                        example: "2011-10-05T14:48:00.000Z"
+                      updated:
+                        type: string
+                        description: >-
+                          The date and time the object was last updated (ISO
+                          timestamp). Is identical to created date after first
+                          creation.
+                        example: "2011-10-05T14:48:00.000Z"
+                      origin:
+                        type: string
+                        description: The source of this object.
+                        example: bezirkskalender
+                      originObjectID:
+                        type: string
+                        description: The original ID of this object in the original system.
+                      availableLanguages:
                         type: array
+                        description: List of languages this object is available in.
+                        example:
+                          - de
+                          - en
                         items:
+                          type: string
+                      externalIDs:
+                        type: object
+                        additionalProperties:
+                          type: string
+                      editableBy:
+                        type: array
+                        description: List of organizations that can edit this object.
+                        items:
+                          type: string
+                    required:
+                      - created
+                      - updated
+                    additionalProperties: false
+                  status:
+                    type: string
+                    enum:
+                      - event.published
+                      - event.unpublished
+                      - event.archived
+                  scheduleStatus:
+                    type: string
+                    enum:
+                      - event.cancelled
+                      - event.postponed
+                      - event.rescheduled
+                      - event.scheduled
+                  schedule:
+                    type: object
+                    properties:
+                      startDate:
+                        type: string
+                        description: >-
+                          The date (year, month, day) the event starts, in
+                          timezone Europe/Berlin.
+                        example: "2023-09-08"
+                      startTime:
+                        type: string
+                        description: The time the event starts, in timezone Europe/Berlin.
+                        example: "20:00:00"
+                      permanentOpening:
+                        type: boolean
+                        description: >-
+                          Indicates whether the event is permanently open (and
+                          has no end date/time).
+                        example: false
+                      doorTime:
+                        type: string
+                        description: >-
+                          The time that guests can enter the venue, in timezone
+                          Europe/Berlin.
+                        example: "19:00:00"
+                      endDate:
+                        type: string
+                        description: >-
+                          The date (year, month, day) the event ends, in
+                          timezone Europe/Berlin.
+                        example: "2023-09-08"
+                      endTime:
+                        type: string
+                        description: The time the event end, in timezone Europe/Berlin.
+                        example: "22:00"
+                    required:
+                      - startDate
+                      - startTime
+                    additionalProperties: false
+                  title:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    description: >-
+                      A string that can be translated into multiple languages,
+                      e.g. { "de": "Konzert", "en": "concert" }
+                    example:
+                      de: Konzert
+                      en: concert
+                  description:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    description: >-
+                      A string that can be translated into multiple languages,
+                      e.g. { "de": "Konzert", "en": "concert" }
+                    example:
+                      de: Konzert
+                      en: concert
+                  pleaseNote:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    description: >-
+                      A string that can be translated into multiple languages,
+                      e.g. { "de": "Konzert", "en": "concert" }
+                    example:
+                      de: Konzert
+                      en: concert
+                  website:
+                    type: string
+                    example: https://example.com/
+                  inLanguages:
+                    type: array
+                    description: List of languages this object is available in.
+                    example:
+                      - de
+                      - en
+                    items:
+                      type: string
+                  tags:
+                    type: array
+                    items:
+                      type: string
+                  locations:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        referenceType:
+                          type: string
+                        referenceId:
+                          type: string
+                        referenceLabel:
                           type: object
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                - type.Event
-                            identifier:
-                              type: string
-                            metadata:
-                              type: object
-                              properties:
-                                created:
-                                  type: string
-                                  description: >-
-                                    The date and time the object was created
-                                    (ISO timestamp).
-                                  example: "2011-10-05T14:48:00.000Z"
-                                updated:
-                                  type: string
-                                  description: >-
-                                    The date and time the object was last
-                                    updated (ISO timestamp). Is identical to
-                                    created date after first creation.
-                                  example: "2011-10-05T14:48:00.000Z"
-                                origin:
-                                  type: string
-                                  description: The source of this object.
-                                  example: bezirkskalender
-                                originObjectID:
-                                  type: string
-                                  description: >-
-                                    The original ID of this object in the
-                                    original system.
-                                availableLanguages:
-                                  type: array
-                                  description: >-
-                                    List of languages this object is available
-                                    in.
-                                  example:
-                                    - de
-                                    - en
-                                  items:
-                                    type: string
-                                externalIDs:
-                                  type: object
-                                  additionalProperties:
-                                    type: string
-                                editableBy:
-                                  type: array
-                                  description: >-
-                                    List of organizations that can edit this
-                                    object.
-                                  items:
-                                    type: string
-                              required:
-                                - created
-                                - updated
-                              additionalProperties: false
-                            status:
-                              type: string
-                              enum:
-                                - event.published
-                                - event.unpublished
-                                - event.archived
-                            scheduleStatus:
-                              type: string
-                              enum:
-                                - event.cancelled
-                                - event.postponed
-                                - event.rescheduled
-                                - event.scheduled
-                            schedule:
-                              type: object
-                              properties:
-                                startDate:
-                                  type: string
-                                  description: >-
-                                    The date (year, month, day) the event
-                                    starts, in timezone Europe/Berlin.
-                                  example: "2023-09-08"
-                                startTime:
-                                  type: string
-                                  description: >-
-                                    The time the event starts, in timezone
-                                    Europe/Berlin.
-                                  example: "20:00:00"
-                                permanentOpening:
-                                  type: boolean
-                                  description: >-
-                                    Indicates whether the event is permanently
-                                    open (and has no end date/time).
-                                  example: false
-                                doorTime:
-                                  type: string
-                                  description: >-
-                                    The time that guests can enter the venue, in
-                                    timezone Europe/Berlin.
-                                  example: "19:00:00"
-                                endDate:
-                                  type: string
-                                  description: >-
-                                    The date (year, month, day) the event ends,
-                                    in timezone Europe/Berlin.
-                                  example: "2023-09-08"
-                                endTime:
-                                  type: string
-                                  description: >-
-                                    The time the event end, in timezone
-                                    Europe/Berlin.
-                                  example: "22:00"
-                              required:
-                                - startDate
-                                - startTime
-                              additionalProperties: false
-                            title:
-                              type: object
-                              additionalProperties:
-                                type: string
-                              description: >-
-                                A string that can be translated into multiple
-                                languages, e.g. { "de": "Konzert", "en":
-                                "concert" }
-                              example:
-                                de: Konzert
-                                en: concert
-                            description:
-                              type: object
-                              additionalProperties:
-                                type: string
-                              description: >-
-                                A string that can be translated into multiple
-                                languages, e.g. { "de": "Konzert", "en":
-                                "concert" }
-                              example:
-                                de: Konzert
-                                en: concert
-                            pleaseNote:
-                              type: object
-                              additionalProperties:
-                                type: string
-                              description: >-
-                                A string that can be translated into multiple
-                                languages, e.g. { "de": "Konzert", "en":
-                                "concert" }
-                              example:
-                                de: Konzert
-                                en: concert
-                            website:
-                              type: string
-                              example: https://example.com/
-                            inLanguages:
-                              type: array
-                              description: List of languages this object is available in.
-                              example:
-                                - de
-                                - en
-                              items:
-                                type: string
-                            tags:
-                              type: array
-                              items:
-                                type: string
-                            locations:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  referenceType:
-                                    type: string
-                                  referenceId:
-                                    type: string
-                                  referenceLabel:
-                                    type: object
-                                    additionalProperties:
-                                      type: string
-                                    description: >-
-                                      A string that can be translated into
-                                      multiple languages, e.g. { "de":
-                                      "Konzert", "en": "concert" }
-                                    example:
-                                      de: Konzert
-                                      en: concert
-                                required:
-                                  - referenceType
-                                  - referenceId
-                                additionalProperties: false
-                            attractions:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  referenceType:
-                                    type: string
-                                  referenceId:
-                                    type: string
-                                  referenceLabel:
-                                    type: object
-                                    additionalProperties:
-                                      type: string
-                                    description: >-
-                                      A string that can be translated into
-                                      multiple languages, e.g. { "de":
-                                      "Konzert", "en": "concert" }
-                                    example:
-                                      de: Konzert
-                                      en: concert
-                                required:
-                                  - referenceType
-                                  - referenceId
-                                additionalProperties: false
-                            organizer:
-                              type: object
-                              properties:
-                                referenceType:
-                                  type: string
-                                referenceId:
-                                  type: string
-                                referenceLabel:
-                                  type: object
-                                  additionalProperties:
-                                    type: string
-                                  description: >-
-                                    A string that can be translated into
-                                    multiple languages, e.g. { "de": "Konzert",
-                                    "en": "concert" }
-                                  example:
-                                    de: Konzert
-                                    en: concert
-                              required:
-                                - referenceType
-                                - referenceId
-                              additionalProperties: false
-                            contact:
-                              type: object
-                              description: >-
-                                A person that is connected to and/or responsible
-                                for the referenced entity.
-                              properties:
-                                name:
-                                  type: string
-                                  description: Full name of the contact person.
-                                  example: Jane Doe
-                                email:
-                                  type: string
-                                  description: Email address of the contact person.
-                                  example: someone@example.com
-                                telephone:
-                                  type: string
-                                  description: Phone number of the contact person.
-                                  example: +49 30 12345678
-                              additionalProperties: false
-                            admission:
-                              type: object
-                              description: >-
-                                Information about the admission to the
-                                event/attraction.
-                              properties:
-                                note:
-                                  type: object
-                                  additionalProperties:
-                                    type: string
-                                  description: >-
-                                    A string that can be translated into
-                                    multiple languages, e.g. { "de": "Konzert",
-                                    "en": "concert" }
-                                  example:
-                                    de: Konzert
-                                    en: concert
-                                ticketType:
-                                  type: string
-                                  enum:
-                                    - ticketType.ticketRequired
-                                    - ticketType.freeOfCharge
-                                registrationType:
-                                  type: string
-                                  enum:
-                                    - registrationType.registrationRequired
-                                    - registrationType.noRegistrationRequired
-                                    - registrationType.registrationDesired
-                                admissionLink:
-                                  type: string
-                                  example: https://example.com/
-                              additionalProperties: false
-                          required:
-                            - type
-                            - identifier
-                            - metadata
-                            - status
-                            - scheduleStatus
-                          additionalProperties: false
+                          additionalProperties:
+                            type: string
+                          description: >-
+                            A string that can be translated into multiple
+                            languages, e.g. { "de": "Konzert", "en": "concert" }
+                          example:
+                            de: Konzert
+                            en: concert
+                      required:
+                        - referenceType
+                        - referenceId
+                      additionalProperties: false
+                  attractions:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        referenceType:
+                          type: string
+                        referenceId:
+                          type: string
+                        referenceLabel:
+                          type: object
+                          additionalProperties:
+                            type: string
+                          description: >-
+                            A string that can be translated into multiple
+                            languages, e.g. { "de": "Konzert", "en": "concert" }
+                          example:
+                            de: Konzert
+                            en: concert
+                      required:
+                        - referenceType
+                        - referenceId
+                      additionalProperties: false
+                  organizer:
+                    type: object
+                    properties:
+                      referenceType:
+                        type: string
+                      referenceId:
+                        type: string
+                      referenceLabel:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                    required:
+                      - referenceType
+                      - referenceId
+                    additionalProperties: false
+                  contact:
+                    type: object
+                    description: >-
+                      A person that is connected to and/or responsible for the
+                      referenced entity.
+                    properties:
+                      name:
+                        type: string
+                        description: Full name of the contact person.
+                        example: Jane Doe
+                      email:
+                        type: string
+                        description: Email address of the contact person.
+                        example: someone@example.com
+                      telephone:
+                        type: string
+                        description: Phone number of the contact person.
+                        example: +49 30 12345678
+                    additionalProperties: false
+                  admission:
+                    type: object
+                    description: Information about the admission to the event/attraction.
+                    properties:
+                      note:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                      ticketType:
+                        type: string
+                        enum:
+                          - ticketType.ticketRequired
+                          - ticketType.freeOfCharge
+                      registrationType:
+                        type: string
+                        enum:
+                          - registrationType.registrationRequired
+                          - registrationType.noRegistrationRequired
+                          - registrationType.registrationDesired
+                      admissionLink:
+                        type: string
+                        example: https://example.com/
+                    additionalProperties: false
+                required:
+                  - type
+                  - identifier
+                  - metadata
+                  - status
+                  - scheduleStatus
+                additionalProperties: false
+            eventsReferences:
+              type: array
+              items:
+                type: object
+                properties:
+                  referenceType:
+                    type: string
+                  referenceId:
+                    type: string
+                  referenceLabel:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    description: >-
+                      A string that can be translated into multiple languages,
+                      e.g. { "de": "Konzert", "en": "concert" }
+                    example:
+                      de: Konzert
+                      en: concert
+                required:
+                  - referenceType
+                  - referenceId
+                additionalProperties: false
       required:
         - success
       additionalProperties: false
@@ -5953,6 +5655,284 @@ components:
                 - referenceType
                 - referenceId
               additionalProperties: false
+          additionalProperties: false
+        related:
+          type: object
+          properties:
+            events:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    enum:
+                      - type.Event
+                  identifier:
+                    type: string
+                  metadata:
+                    type: object
+                    properties:
+                      created:
+                        type: string
+                        description: >-
+                          The date and time the object was created (ISO
+                          timestamp).
+                        example: "2011-10-05T14:48:00.000Z"
+                      updated:
+                        type: string
+                        description: >-
+                          The date and time the object was last updated (ISO
+                          timestamp). Is identical to created date after first
+                          creation.
+                        example: "2011-10-05T14:48:00.000Z"
+                      origin:
+                        type: string
+                        description: The source of this object.
+                        example: bezirkskalender
+                      originObjectID:
+                        type: string
+                        description: The original ID of this object in the original system.
+                      availableLanguages:
+                        type: array
+                        description: List of languages this object is available in.
+                        example:
+                          - de
+                          - en
+                        items:
+                          type: string
+                      externalIDs:
+                        type: object
+                        additionalProperties:
+                          type: string
+                      editableBy:
+                        type: array
+                        description: List of organizations that can edit this object.
+                        items:
+                          type: string
+                    required:
+                      - created
+                      - updated
+                    additionalProperties: false
+                  status:
+                    type: string
+                    enum:
+                      - event.published
+                      - event.unpublished
+                      - event.archived
+                  scheduleStatus:
+                    type: string
+                    enum:
+                      - event.cancelled
+                      - event.postponed
+                      - event.rescheduled
+                      - event.scheduled
+                  schedule:
+                    type: object
+                    properties:
+                      startDate:
+                        type: string
+                        description: >-
+                          The date (year, month, day) the event starts, in
+                          timezone Europe/Berlin.
+                        example: "2023-09-08"
+                      startTime:
+                        type: string
+                        description: The time the event starts, in timezone Europe/Berlin.
+                        example: "20:00:00"
+                      permanentOpening:
+                        type: boolean
+                        description: >-
+                          Indicates whether the event is permanently open (and
+                          has no end date/time).
+                        example: false
+                      doorTime:
+                        type: string
+                        description: >-
+                          The time that guests can enter the venue, in timezone
+                          Europe/Berlin.
+                        example: "19:00:00"
+                      endDate:
+                        type: string
+                        description: >-
+                          The date (year, month, day) the event ends, in
+                          timezone Europe/Berlin.
+                        example: "2023-09-08"
+                      endTime:
+                        type: string
+                        description: The time the event end, in timezone Europe/Berlin.
+                        example: "22:00"
+                    required:
+                      - startDate
+                      - startTime
+                    additionalProperties: false
+                  title:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    description: >-
+                      A string that can be translated into multiple languages,
+                      e.g. { "de": "Konzert", "en": "concert" }
+                    example:
+                      de: Konzert
+                      en: concert
+                  description:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    description: >-
+                      A string that can be translated into multiple languages,
+                      e.g. { "de": "Konzert", "en": "concert" }
+                    example:
+                      de: Konzert
+                      en: concert
+                  pleaseNote:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    description: >-
+                      A string that can be translated into multiple languages,
+                      e.g. { "de": "Konzert", "en": "concert" }
+                    example:
+                      de: Konzert
+                      en: concert
+                  website:
+                    type: string
+                    example: https://example.com/
+                  inLanguages:
+                    type: array
+                    description: List of languages this object is available in.
+                    example:
+                      - de
+                      - en
+                    items:
+                      type: string
+                  tags:
+                    type: array
+                    items:
+                      type: string
+                  locations:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        referenceType:
+                          type: string
+                        referenceId:
+                          type: string
+                        referenceLabel:
+                          type: object
+                          additionalProperties:
+                            type: string
+                          description: >-
+                            A string that can be translated into multiple
+                            languages, e.g. { "de": "Konzert", "en": "concert" }
+                          example:
+                            de: Konzert
+                            en: concert
+                      required:
+                        - referenceType
+                        - referenceId
+                      additionalProperties: false
+                  attractions:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        referenceType:
+                          type: string
+                        referenceId:
+                          type: string
+                        referenceLabel:
+                          type: object
+                          additionalProperties:
+                            type: string
+                          description: >-
+                            A string that can be translated into multiple
+                            languages, e.g. { "de": "Konzert", "en": "concert" }
+                          example:
+                            de: Konzert
+                            en: concert
+                      required:
+                        - referenceType
+                        - referenceId
+                      additionalProperties: false
+                  organizer:
+                    type: object
+                    properties:
+                      referenceType:
+                        type: string
+                      referenceId:
+                        type: string
+                      referenceLabel:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                    required:
+                      - referenceType
+                      - referenceId
+                    additionalProperties: false
+                  contact:
+                    type: object
+                    description: >-
+                      A person that is connected to and/or responsible for the
+                      referenced entity.
+                    properties:
+                      name:
+                        type: string
+                        description: Full name of the contact person.
+                        example: Jane Doe
+                      email:
+                        type: string
+                        description: Email address of the contact person.
+                        example: someone@example.com
+                      telephone:
+                        type: string
+                        description: Phone number of the contact person.
+                        example: +49 30 12345678
+                    additionalProperties: false
+                  admission:
+                    type: object
+                    description: Information about the admission to the event/attraction.
+                    properties:
+                      note:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                      ticketType:
+                        type: string
+                        enum:
+                          - ticketType.ticketRequired
+                          - ticketType.freeOfCharge
+                      registrationType:
+                        type: string
+                        enum:
+                          - registrationType.registrationRequired
+                          - registrationType.noRegistrationRequired
+                          - registrationType.registrationDesired
+                      admissionLink:
+                        type: string
+                        example: https://example.com/
+                    additionalProperties: false
+                required:
+                  - type
+                  - identifier
+                  - metadata
+                  - status
+                  - scheduleStatus
+                additionalProperties: false
           additionalProperties: false
       required:
         - success
@@ -7757,6 +7737,180 @@ components:
                       - referenceType
                       - referenceId
                     additionalProperties: false
+        related:
+          type: object
+          properties:
+            attractions:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    enum:
+                      - type.Attraction
+                  identifier:
+                    type: string
+                  metadata:
+                    type: object
+                    properties:
+                      created:
+                        type: string
+                        description: >-
+                          The date and time the object was created (ISO
+                          timestamp).
+                        example: "2011-10-05T14:48:00.000Z"
+                      updated:
+                        type: string
+                        description: >-
+                          The date and time the object was last updated (ISO
+                          timestamp). Is identical to created date after first
+                          creation.
+                        example: "2011-10-05T14:48:00.000Z"
+                      origin:
+                        type: string
+                        description: The source of this object.
+                        example: bezirkskalender
+                      originObjectID:
+                        type: string
+                        description: The original ID of this object in the original system.
+                      availableLanguages:
+                        type: array
+                        description: List of languages this object is available in.
+                        example:
+                          - de
+                          - en
+                        items:
+                          type: string
+                      externalIDs:
+                        type: object
+                        additionalProperties:
+                          type: string
+                      editableBy:
+                        type: array
+                        description: List of organizations that can edit this object.
+                        items:
+                          type: string
+                    required:
+                      - created
+                      - updated
+                    additionalProperties: false
+                  status:
+                    type: string
+                    enum:
+                      - attraction.published
+                      - attraction.unpublished
+                      - attraction.archived
+                  title:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    description: The main title of the attraction.
+                    example:
+                      de: Konzert
+                      en: concert
+                  description:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    description: >-
+                      A string that can be translated into multiple languages,
+                      e.g. { "de": "Konzert", "en": "concert" }
+                    example:
+                      de: Eine Beschreibung
+                      en: Some description
+                  pleaseNote:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    description: >-
+                      Any important information for the attendees of the
+                      attraction.
+                    example:
+                      de: Achtung, laute Geräusche
+                      en: Warning, loud noises
+                  website:
+                    type: string
+                    example: https://example.com/
+                  curator:
+                    type: object
+                    properties:
+                      referenceType:
+                        type: string
+                      referenceId:
+                        type: string
+                      referenceLabel:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                    required:
+                      - referenceType
+                      - referenceId
+                    additionalProperties: false
+                    description: The curating organization of this attraction.
+                  inLanguages:
+                    type: array
+                    description: List of languages this object is available in.
+                    example:
+                      - de
+                      - en
+                    items:
+                      type: string
+                  tags:
+                    type: array
+                    description: List of tags for this attraction.
+                    items:
+                      type: string
+                  externalLinks:
+                    type: array
+                    description: Links to external resources related to this object.
+                    items:
+                      type: object
+                      properties:
+                        displayName:
+                          type: string
+                          example: Website
+                        url:
+                          type: string
+                          example: https://example.com/
+                      required:
+                        - url
+                      additionalProperties: false
+                required:
+                  - type
+                  - identifier
+                  - metadata
+                  - status
+                  - title
+            attractionsReferences:
+              type: array
+              items:
+                type: object
+                properties:
+                  referenceType:
+                    type: string
+                  referenceId:
+                    type: string
+                  referenceLabel:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    description: >-
+                      A string that can be translated into multiple languages,
+                      e.g. { "de": "Konzert", "en": "concert" }
+                    example:
+                      de: Konzert
+                      en: concert
+                required:
+                  - referenceType
+                  - referenceId
+                additionalProperties: false
       required:
         - success
       additionalProperties: false
@@ -8388,6 +8542,180 @@ components:
                       - referenceType
                       - referenceId
                     additionalProperties: false
+        related:
+          type: object
+          properties:
+            attractions:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    enum:
+                      - type.Attraction
+                  identifier:
+                    type: string
+                  metadata:
+                    type: object
+                    properties:
+                      created:
+                        type: string
+                        description: >-
+                          The date and time the object was created (ISO
+                          timestamp).
+                        example: "2011-10-05T14:48:00.000Z"
+                      updated:
+                        type: string
+                        description: >-
+                          The date and time the object was last updated (ISO
+                          timestamp). Is identical to created date after first
+                          creation.
+                        example: "2011-10-05T14:48:00.000Z"
+                      origin:
+                        type: string
+                        description: The source of this object.
+                        example: bezirkskalender
+                      originObjectID:
+                        type: string
+                        description: The original ID of this object in the original system.
+                      availableLanguages:
+                        type: array
+                        description: List of languages this object is available in.
+                        example:
+                          - de
+                          - en
+                        items:
+                          type: string
+                      externalIDs:
+                        type: object
+                        additionalProperties:
+                          type: string
+                      editableBy:
+                        type: array
+                        description: List of organizations that can edit this object.
+                        items:
+                          type: string
+                    required:
+                      - created
+                      - updated
+                    additionalProperties: false
+                  status:
+                    type: string
+                    enum:
+                      - attraction.published
+                      - attraction.unpublished
+                      - attraction.archived
+                  title:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    description: The main title of the attraction.
+                    example:
+                      de: Konzert
+                      en: concert
+                  description:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    description: >-
+                      A string that can be translated into multiple languages,
+                      e.g. { "de": "Konzert", "en": "concert" }
+                    example:
+                      de: Eine Beschreibung
+                      en: Some description
+                  pleaseNote:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    description: >-
+                      Any important information for the attendees of the
+                      attraction.
+                    example:
+                      de: Achtung, laute Geräusche
+                      en: Warning, loud noises
+                  website:
+                    type: string
+                    example: https://example.com/
+                  curator:
+                    type: object
+                    properties:
+                      referenceType:
+                        type: string
+                      referenceId:
+                        type: string
+                      referenceLabel:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >-
+                          A string that can be translated into multiple
+                          languages, e.g. { "de": "Konzert", "en": "concert" }
+                        example:
+                          de: Konzert
+                          en: concert
+                    required:
+                      - referenceType
+                      - referenceId
+                    additionalProperties: false
+                    description: The curating organization of this attraction.
+                  inLanguages:
+                    type: array
+                    description: List of languages this object is available in.
+                    example:
+                      - de
+                      - en
+                    items:
+                      type: string
+                  tags:
+                    type: array
+                    description: List of tags for this attraction.
+                    items:
+                      type: string
+                  externalLinks:
+                    type: array
+                    description: Links to external resources related to this object.
+                    items:
+                      type: object
+                      properties:
+                        displayName:
+                          type: string
+                          example: Website
+                        url:
+                          type: string
+                          example: https://example.com/
+                      required:
+                        - url
+                      additionalProperties: false
+                required:
+                  - type
+                  - identifier
+                  - metadata
+                  - status
+                  - title
+            attractionsReferences:
+              type: array
+              items:
+                type: object
+                properties:
+                  referenceType:
+                    type: string
+                  referenceId:
+                    type: string
+                  referenceLabel:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    description: >-
+                      A string that can be translated into multiple languages,
+                      e.g. { "de": "Konzert", "en": "concert" }
+                    example:
+                      de: Konzert
+                      en: concert
+                required:
+                  - referenceType
+                  - referenceId
+                additionalProperties: false
       required:
         - success
       additionalProperties: false

--- a/src/schemas/kulturdaten.berlin.openapi.generated.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.generated.yml
@@ -130,10 +130,20 @@ paths:
           description: Returns only the Attractions editable by the entered Organization-ID
           schema:
             type: string
-        - name: tags
+        - name: anyTags
           in: query
           required: false
           description: Returns only the Attractions that match any of the specified tags
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+        - name: allTags
+          in: query
+          required: false
+          description: Returns only the Attractions that match all of the specified tags
           schema:
             type: array
             items:

--- a/src/schemas/kulturdaten.berlin.openapi.generated.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.generated.yml
@@ -425,14 +425,11 @@ paths:
         - name: inFuture
           in: query
           required: false
-          description: >
-            Filters the events based on their occurrence in the future.
-
-            When set to true, returns only events that are scheduled to occur in
-            the future.
-
-            When set to false, returns events regardless of their scheduled
-            date.
+          description: >-
+            Filters the events based on their occurrence in the future. When set
+            to true, returns only events that are scheduled to occur in the
+            future. When set to false, returns events regardless of their
+            scheduled date.
           schema:
             type: boolean
             default: true
@@ -483,16 +480,12 @@ paths:
         - name: isFreeOfCharge
           in: query
           required: false
-          description: >
-            Filters the events based on the admission charge. 
-
-            When set to true, returns only the events that are free of charge. 
-
-            When set to false, returns events regardless of their admission
+          description: >-
+            Filters the events based on the admission charge. When set to true,
+            returns only the events that are free of charge. When set to false,
+            returns events regardless of their admission charge status. If not
+            provided, all events are returned irrespective of their admission
             charge status.
-
-            If not provided, all events are returned irrespective of their
-            admission charge status.
           schema:
             type: boolean
       responses:

--- a/src/schemas/kulturdaten.berlin.openapi.generated.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.generated.yml
@@ -130,6 +130,21 @@ paths:
           description: Returns only the Attractions editable by the entered Organization-ID
           schema:
             type: string
+        - name: withEvents
+          description: >
+            Specifies whether to include a list of related events for each
+            attraction in the response. 
+
+            When set to true, the response will contain an additional field
+            listing events associated with each attraction. 
+
+            If false or omitted, the response includes only the attractions
+            without their related events.
+          in: query
+          required: false
+          example: false
+          schema:
+            type: boolean
       responses:
         "200":
           description: OK
@@ -4426,6 +4441,458 @@ components:
                       - referenceType
                       - referenceId
                     additionalProperties: false
+                attractionsWithEvents:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      attraction:
+                        type: object
+                        properties:
+                          type:
+                            type: string
+                            enum:
+                              - type.Attraction
+                          identifier:
+                            type: string
+                          metadata:
+                            type: object
+                            properties:
+                              created:
+                                type: string
+                                description: >-
+                                  The date and time the object was created (ISO
+                                  timestamp).
+                                example: "2011-10-05T14:48:00.000Z"
+                              updated:
+                                type: string
+                                description: >-
+                                  The date and time the object was last updated
+                                  (ISO timestamp). Is identical to created date
+                                  after first creation.
+                                example: "2011-10-05T14:48:00.000Z"
+                              origin:
+                                type: string
+                                description: The source of this object.
+                                example: bezirkskalender
+                              originObjectID:
+                                type: string
+                                description: >-
+                                  The original ID of this object in the original
+                                  system.
+                              availableLanguages:
+                                type: array
+                                description: List of languages this object is available in.
+                                example:
+                                  - de
+                                  - en
+                                items:
+                                  type: string
+                              externalIDs:
+                                type: object
+                                additionalProperties:
+                                  type: string
+                              editableBy:
+                                type: array
+                                description: >-
+                                  List of organizations that can edit this
+                                  object.
+                                items:
+                                  type: string
+                            required:
+                              - created
+                              - updated
+                            additionalProperties: false
+                          status:
+                            type: string
+                            enum:
+                              - attraction.published
+                              - attraction.unpublished
+                              - attraction.archived
+                          title:
+                            type: object
+                            additionalProperties:
+                              type: string
+                            description: The main title of the attraction.
+                            example:
+                              de: Konzert
+                              en: concert
+                          description:
+                            type: object
+                            additionalProperties:
+                              type: string
+                            description: >-
+                              A string that can be translated into multiple
+                              languages, e.g. { "de": "Konzert", "en": "concert"
+                              }
+                            example:
+                              de: Eine Beschreibung
+                              en: Some description
+                          pleaseNote:
+                            type: object
+                            additionalProperties:
+                              type: string
+                            description: >-
+                              Any important information for the attendees of the
+                              attraction.
+                            example:
+                              de: Achtung, laute Geräusche
+                              en: Warning, loud noises
+                          website:
+                            type: string
+                            example: https://example.com/
+                          curator:
+                            type: object
+                            properties:
+                              referenceType:
+                                type: string
+                              referenceId:
+                                type: string
+                              referenceLabel:
+                                type: object
+                                additionalProperties:
+                                  type: string
+                                description: >-
+                                  A string that can be translated into multiple
+                                  languages, e.g. { "de": "Konzert", "en":
+                                  "concert" }
+                                example:
+                                  de: Konzert
+                                  en: concert
+                            required:
+                              - referenceType
+                              - referenceId
+                            additionalProperties: false
+                            description: The curating organization of this attraction.
+                          inLanguages:
+                            type: array
+                            description: List of languages this object is available in.
+                            example:
+                              - de
+                              - en
+                            items:
+                              type: string
+                          tags:
+                            type: array
+                            description: List of tags for this attraction.
+                            items:
+                              type: string
+                          externalLinks:
+                            type: array
+                            description: >-
+                              Links to external resources related to this
+                              object.
+                            items:
+                              type: object
+                              properties:
+                                displayName:
+                                  type: string
+                                  example: Website
+                                url:
+                                  type: string
+                                  example: https://example.com/
+                              required:
+                                - url
+                              additionalProperties: false
+                        required:
+                          - type
+                          - identifier
+                          - metadata
+                          - status
+                          - title
+                      events:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - type.Event
+                            identifier:
+                              type: string
+                            metadata:
+                              type: object
+                              properties:
+                                created:
+                                  type: string
+                                  description: >-
+                                    The date and time the object was created
+                                    (ISO timestamp).
+                                  example: "2011-10-05T14:48:00.000Z"
+                                updated:
+                                  type: string
+                                  description: >-
+                                    The date and time the object was last
+                                    updated (ISO timestamp). Is identical to
+                                    created date after first creation.
+                                  example: "2011-10-05T14:48:00.000Z"
+                                origin:
+                                  type: string
+                                  description: The source of this object.
+                                  example: bezirkskalender
+                                originObjectID:
+                                  type: string
+                                  description: >-
+                                    The original ID of this object in the
+                                    original system.
+                                availableLanguages:
+                                  type: array
+                                  description: >-
+                                    List of languages this object is available
+                                    in.
+                                  example:
+                                    - de
+                                    - en
+                                  items:
+                                    type: string
+                                externalIDs:
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                                editableBy:
+                                  type: array
+                                  description: >-
+                                    List of organizations that can edit this
+                                    object.
+                                  items:
+                                    type: string
+                              required:
+                                - created
+                                - updated
+                              additionalProperties: false
+                            status:
+                              type: string
+                              enum:
+                                - event.published
+                                - event.unpublished
+                                - event.archived
+                            scheduleStatus:
+                              type: string
+                              enum:
+                                - event.cancelled
+                                - event.postponed
+                                - event.rescheduled
+                                - event.scheduled
+                            schedule:
+                              type: object
+                              properties:
+                                startDate:
+                                  type: string
+                                  description: >-
+                                    The date (year, month, day) the event
+                                    starts, in timezone Europe/Berlin.
+                                  example: "2023-09-08"
+                                startTime:
+                                  type: string
+                                  description: >-
+                                    The time the event starts, in timezone
+                                    Europe/Berlin.
+                                  example: "20:00:00"
+                                permanentOpening:
+                                  type: boolean
+                                  description: >-
+                                    Indicates whether the event is permanently
+                                    open (and has no end date/time).
+                                  example: false
+                                doorTime:
+                                  type: string
+                                  description: >-
+                                    The time that guests can enter the venue, in
+                                    timezone Europe/Berlin.
+                                  example: "19:00:00"
+                                endDate:
+                                  type: string
+                                  description: >-
+                                    The date (year, month, day) the event ends,
+                                    in timezone Europe/Berlin.
+                                  example: "2023-09-08"
+                                endTime:
+                                  type: string
+                                  description: >-
+                                    The time the event end, in timezone
+                                    Europe/Berlin.
+                                  example: "22:00"
+                              required:
+                                - startDate
+                                - startTime
+                              additionalProperties: false
+                            title:
+                              type: object
+                              additionalProperties:
+                                type: string
+                              description: >-
+                                A string that can be translated into multiple
+                                languages, e.g. { "de": "Konzert", "en":
+                                "concert" }
+                              example:
+                                de: Konzert
+                                en: concert
+                            description:
+                              type: object
+                              additionalProperties:
+                                type: string
+                              description: >-
+                                A string that can be translated into multiple
+                                languages, e.g. { "de": "Konzert", "en":
+                                "concert" }
+                              example:
+                                de: Konzert
+                                en: concert
+                            pleaseNote:
+                              type: object
+                              additionalProperties:
+                                type: string
+                              description: >-
+                                A string that can be translated into multiple
+                                languages, e.g. { "de": "Konzert", "en":
+                                "concert" }
+                              example:
+                                de: Konzert
+                                en: concert
+                            website:
+                              type: string
+                              example: https://example.com/
+                            inLanguages:
+                              type: array
+                              description: List of languages this object is available in.
+                              example:
+                                - de
+                                - en
+                              items:
+                                type: string
+                            tags:
+                              type: array
+                              items:
+                                type: string
+                            locations:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  referenceType:
+                                    type: string
+                                  referenceId:
+                                    type: string
+                                  referenceLabel:
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                    description: >-
+                                      A string that can be translated into
+                                      multiple languages, e.g. { "de":
+                                      "Konzert", "en": "concert" }
+                                    example:
+                                      de: Konzert
+                                      en: concert
+                                required:
+                                  - referenceType
+                                  - referenceId
+                                additionalProperties: false
+                            attractions:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  referenceType:
+                                    type: string
+                                  referenceId:
+                                    type: string
+                                  referenceLabel:
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                    description: >-
+                                      A string that can be translated into
+                                      multiple languages, e.g. { "de":
+                                      "Konzert", "en": "concert" }
+                                    example:
+                                      de: Konzert
+                                      en: concert
+                                required:
+                                  - referenceType
+                                  - referenceId
+                                additionalProperties: false
+                            organizer:
+                              type: object
+                              properties:
+                                referenceType:
+                                  type: string
+                                referenceId:
+                                  type: string
+                                referenceLabel:
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                                  description: >-
+                                    A string that can be translated into
+                                    multiple languages, e.g. { "de": "Konzert",
+                                    "en": "concert" }
+                                  example:
+                                    de: Konzert
+                                    en: concert
+                              required:
+                                - referenceType
+                                - referenceId
+                              additionalProperties: false
+                            contact:
+                              type: object
+                              description: >-
+                                A person that is connected to and/or responsible
+                                for the referenced entity.
+                              properties:
+                                name:
+                                  type: string
+                                  description: Full name of the contact person.
+                                  example: Jane Doe
+                                email:
+                                  type: string
+                                  description: Email address of the contact person.
+                                  example: someone@example.com
+                                telephone:
+                                  type: string
+                                  description: Phone number of the contact person.
+                                  example: +49 30 12345678
+                              additionalProperties: false
+                            admission:
+                              type: object
+                              description: >-
+                                Information about the admission to the
+                                event/attraction.
+                              properties:
+                                note:
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                                  description: >-
+                                    A string that can be translated into
+                                    multiple languages, e.g. { "de": "Konzert",
+                                    "en": "concert" }
+                                  example:
+                                    de: Konzert
+                                    en: concert
+                                ticketType:
+                                  type: string
+                                  enum:
+                                    - ticketType.ticketRequired
+                                    - ticketType.freeOfCharge
+                                registrationType:
+                                  type: string
+                                  enum:
+                                    - registrationType.registrationRequired
+                                    - registrationType.noRegistrationRequired
+                                    - registrationType.registrationDesired
+                                admissionLink:
+                                  type: string
+                                  example: https://example.com/
+                              additionalProperties: false
+                          required:
+                            - type
+                            - identifier
+                            - metadata
+                            - status
+                            - scheduleStatus
+                          additionalProperties: false
       required:
         - success
       additionalProperties: false
@@ -4771,6 +5238,458 @@ components:
                       - referenceType
                       - referenceId
                     additionalProperties: false
+                attractionsWithEvents:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      attraction:
+                        type: object
+                        properties:
+                          type:
+                            type: string
+                            enum:
+                              - type.Attraction
+                          identifier:
+                            type: string
+                          metadata:
+                            type: object
+                            properties:
+                              created:
+                                type: string
+                                description: >-
+                                  The date and time the object was created (ISO
+                                  timestamp).
+                                example: "2011-10-05T14:48:00.000Z"
+                              updated:
+                                type: string
+                                description: >-
+                                  The date and time the object was last updated
+                                  (ISO timestamp). Is identical to created date
+                                  after first creation.
+                                example: "2011-10-05T14:48:00.000Z"
+                              origin:
+                                type: string
+                                description: The source of this object.
+                                example: bezirkskalender
+                              originObjectID:
+                                type: string
+                                description: >-
+                                  The original ID of this object in the original
+                                  system.
+                              availableLanguages:
+                                type: array
+                                description: List of languages this object is available in.
+                                example:
+                                  - de
+                                  - en
+                                items:
+                                  type: string
+                              externalIDs:
+                                type: object
+                                additionalProperties:
+                                  type: string
+                              editableBy:
+                                type: array
+                                description: >-
+                                  List of organizations that can edit this
+                                  object.
+                                items:
+                                  type: string
+                            required:
+                              - created
+                              - updated
+                            additionalProperties: false
+                          status:
+                            type: string
+                            enum:
+                              - attraction.published
+                              - attraction.unpublished
+                              - attraction.archived
+                          title:
+                            type: object
+                            additionalProperties:
+                              type: string
+                            description: The main title of the attraction.
+                            example:
+                              de: Konzert
+                              en: concert
+                          description:
+                            type: object
+                            additionalProperties:
+                              type: string
+                            description: >-
+                              A string that can be translated into multiple
+                              languages, e.g. { "de": "Konzert", "en": "concert"
+                              }
+                            example:
+                              de: Eine Beschreibung
+                              en: Some description
+                          pleaseNote:
+                            type: object
+                            additionalProperties:
+                              type: string
+                            description: >-
+                              Any important information for the attendees of the
+                              attraction.
+                            example:
+                              de: Achtung, laute Geräusche
+                              en: Warning, loud noises
+                          website:
+                            type: string
+                            example: https://example.com/
+                          curator:
+                            type: object
+                            properties:
+                              referenceType:
+                                type: string
+                              referenceId:
+                                type: string
+                              referenceLabel:
+                                type: object
+                                additionalProperties:
+                                  type: string
+                                description: >-
+                                  A string that can be translated into multiple
+                                  languages, e.g. { "de": "Konzert", "en":
+                                  "concert" }
+                                example:
+                                  de: Konzert
+                                  en: concert
+                            required:
+                              - referenceType
+                              - referenceId
+                            additionalProperties: false
+                            description: The curating organization of this attraction.
+                          inLanguages:
+                            type: array
+                            description: List of languages this object is available in.
+                            example:
+                              - de
+                              - en
+                            items:
+                              type: string
+                          tags:
+                            type: array
+                            description: List of tags for this attraction.
+                            items:
+                              type: string
+                          externalLinks:
+                            type: array
+                            description: >-
+                              Links to external resources related to this
+                              object.
+                            items:
+                              type: object
+                              properties:
+                                displayName:
+                                  type: string
+                                  example: Website
+                                url:
+                                  type: string
+                                  example: https://example.com/
+                              required:
+                                - url
+                              additionalProperties: false
+                        required:
+                          - type
+                          - identifier
+                          - metadata
+                          - status
+                          - title
+                      events:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - type.Event
+                            identifier:
+                              type: string
+                            metadata:
+                              type: object
+                              properties:
+                                created:
+                                  type: string
+                                  description: >-
+                                    The date and time the object was created
+                                    (ISO timestamp).
+                                  example: "2011-10-05T14:48:00.000Z"
+                                updated:
+                                  type: string
+                                  description: >-
+                                    The date and time the object was last
+                                    updated (ISO timestamp). Is identical to
+                                    created date after first creation.
+                                  example: "2011-10-05T14:48:00.000Z"
+                                origin:
+                                  type: string
+                                  description: The source of this object.
+                                  example: bezirkskalender
+                                originObjectID:
+                                  type: string
+                                  description: >-
+                                    The original ID of this object in the
+                                    original system.
+                                availableLanguages:
+                                  type: array
+                                  description: >-
+                                    List of languages this object is available
+                                    in.
+                                  example:
+                                    - de
+                                    - en
+                                  items:
+                                    type: string
+                                externalIDs:
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                                editableBy:
+                                  type: array
+                                  description: >-
+                                    List of organizations that can edit this
+                                    object.
+                                  items:
+                                    type: string
+                              required:
+                                - created
+                                - updated
+                              additionalProperties: false
+                            status:
+                              type: string
+                              enum:
+                                - event.published
+                                - event.unpublished
+                                - event.archived
+                            scheduleStatus:
+                              type: string
+                              enum:
+                                - event.cancelled
+                                - event.postponed
+                                - event.rescheduled
+                                - event.scheduled
+                            schedule:
+                              type: object
+                              properties:
+                                startDate:
+                                  type: string
+                                  description: >-
+                                    The date (year, month, day) the event
+                                    starts, in timezone Europe/Berlin.
+                                  example: "2023-09-08"
+                                startTime:
+                                  type: string
+                                  description: >-
+                                    The time the event starts, in timezone
+                                    Europe/Berlin.
+                                  example: "20:00:00"
+                                permanentOpening:
+                                  type: boolean
+                                  description: >-
+                                    Indicates whether the event is permanently
+                                    open (and has no end date/time).
+                                  example: false
+                                doorTime:
+                                  type: string
+                                  description: >-
+                                    The time that guests can enter the venue, in
+                                    timezone Europe/Berlin.
+                                  example: "19:00:00"
+                                endDate:
+                                  type: string
+                                  description: >-
+                                    The date (year, month, day) the event ends,
+                                    in timezone Europe/Berlin.
+                                  example: "2023-09-08"
+                                endTime:
+                                  type: string
+                                  description: >-
+                                    The time the event end, in timezone
+                                    Europe/Berlin.
+                                  example: "22:00"
+                              required:
+                                - startDate
+                                - startTime
+                              additionalProperties: false
+                            title:
+                              type: object
+                              additionalProperties:
+                                type: string
+                              description: >-
+                                A string that can be translated into multiple
+                                languages, e.g. { "de": "Konzert", "en":
+                                "concert" }
+                              example:
+                                de: Konzert
+                                en: concert
+                            description:
+                              type: object
+                              additionalProperties:
+                                type: string
+                              description: >-
+                                A string that can be translated into multiple
+                                languages, e.g. { "de": "Konzert", "en":
+                                "concert" }
+                              example:
+                                de: Konzert
+                                en: concert
+                            pleaseNote:
+                              type: object
+                              additionalProperties:
+                                type: string
+                              description: >-
+                                A string that can be translated into multiple
+                                languages, e.g. { "de": "Konzert", "en":
+                                "concert" }
+                              example:
+                                de: Konzert
+                                en: concert
+                            website:
+                              type: string
+                              example: https://example.com/
+                            inLanguages:
+                              type: array
+                              description: List of languages this object is available in.
+                              example:
+                                - de
+                                - en
+                              items:
+                                type: string
+                            tags:
+                              type: array
+                              items:
+                                type: string
+                            locations:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  referenceType:
+                                    type: string
+                                  referenceId:
+                                    type: string
+                                  referenceLabel:
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                    description: >-
+                                      A string that can be translated into
+                                      multiple languages, e.g. { "de":
+                                      "Konzert", "en": "concert" }
+                                    example:
+                                      de: Konzert
+                                      en: concert
+                                required:
+                                  - referenceType
+                                  - referenceId
+                                additionalProperties: false
+                            attractions:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  referenceType:
+                                    type: string
+                                  referenceId:
+                                    type: string
+                                  referenceLabel:
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                    description: >-
+                                      A string that can be translated into
+                                      multiple languages, e.g. { "de":
+                                      "Konzert", "en": "concert" }
+                                    example:
+                                      de: Konzert
+                                      en: concert
+                                required:
+                                  - referenceType
+                                  - referenceId
+                                additionalProperties: false
+                            organizer:
+                              type: object
+                              properties:
+                                referenceType:
+                                  type: string
+                                referenceId:
+                                  type: string
+                                referenceLabel:
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                                  description: >-
+                                    A string that can be translated into
+                                    multiple languages, e.g. { "de": "Konzert",
+                                    "en": "concert" }
+                                  example:
+                                    de: Konzert
+                                    en: concert
+                              required:
+                                - referenceType
+                                - referenceId
+                              additionalProperties: false
+                            contact:
+                              type: object
+                              description: >-
+                                A person that is connected to and/or responsible
+                                for the referenced entity.
+                              properties:
+                                name:
+                                  type: string
+                                  description: Full name of the contact person.
+                                  example: Jane Doe
+                                email:
+                                  type: string
+                                  description: Email address of the contact person.
+                                  example: someone@example.com
+                                telephone:
+                                  type: string
+                                  description: Phone number of the contact person.
+                                  example: +49 30 12345678
+                              additionalProperties: false
+                            admission:
+                              type: object
+                              description: >-
+                                Information about the admission to the
+                                event/attraction.
+                              properties:
+                                note:
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                                  description: >-
+                                    A string that can be translated into
+                                    multiple languages, e.g. { "de": "Konzert",
+                                    "en": "concert" }
+                                  example:
+                                    de: Konzert
+                                    en: concert
+                                ticketType:
+                                  type: string
+                                  enum:
+                                    - ticketType.ticketRequired
+                                    - ticketType.freeOfCharge
+                                registrationType:
+                                  type: string
+                                  enum:
+                                    - registrationType.registrationRequired
+                                    - registrationType.noRegistrationRequired
+                                    - registrationType.registrationDesired
+                                admissionLink:
+                                  type: string
+                                  example: https://example.com/
+                              additionalProperties: false
+                          required:
+                            - type
+                            - identifier
+                            - metadata
+                            - status
+                            - scheduleStatus
+                          additionalProperties: false
       required:
         - success
       additionalProperties: false

--- a/src/schemas/kulturdaten.berlin.openapi.generated.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.generated.yml
@@ -434,6 +434,12 @@ paths:
           description: Returns only the events that include the specified Attraction-ID
           schema:
             type: string
+        - name: isFreeOfCharge
+          in: query
+          required: false
+          description: Returns only the events that are free of charge
+          schema:
+            type: boolean
       responses:
         "200":
           description: OK

--- a/src/schemas/kulturdaten.berlin.openapi.generated.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.generated.yml
@@ -130,6 +130,16 @@ paths:
           description: Returns only the Attractions editable by the entered Organization-ID
           schema:
             type: string
+        - name: tags
+          in: query
+          required: false
+          description: Returns only the Attractions that match any of the specified tags
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
       responses:
         "200":
           description: OK

--- a/src/schemas/kulturdaten.berlin.openapi.generated.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.generated.yml
@@ -427,6 +427,26 @@ paths:
           schema:
             type: boolean
             default: true
+        - name: startDate
+          in: query
+          required: false
+          description: >-
+            The start date of the range for filtering events. Events on or after
+            this date will be included. The date should be in YYYY-MM-DD format.
+          schema:
+            type: string
+            format: date
+            example: "2023-01-01"
+        - name: endDate
+          in: query
+          required: false
+          description: >-
+            The end date of the range for filtering events. Events on or before
+            this date will be included. The date should be in YYYY-MM-DD format.
+          schema:
+            type: string
+            format: date
+            example: "2023-12-31"
         - name: organizedBy
           in: query
           required: false

--- a/src/schemas/kulturdaten.berlin.openapi.generated.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.generated.yml
@@ -800,6 +800,30 @@ paths:
           description: Returns only the locations editable by the entered Organization-ID
           schema:
             type: string
+        - name: anyAccessibilities
+          in: query
+          required: false
+          description: >-
+            Returns only the Locations that match any of the specified
+            accessibility tags
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+        - name: allAccessibilities
+          in: query
+          required: false
+          description: >-
+            Returns only the Locations that match all of the specified
+            accessibility tags
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
       responses:
         "200":
           description: OK
@@ -1761,7 +1785,7 @@ components:
         type: number
     pageSize:
       name: pageSize
-      description: Default value is 30
+      description: Default value is 30. Max value is 500.
       in: query
       required: false
       example: 30

--- a/src/schemas/kulturdaten.berlin.openapi.generated.yml
+++ b/src/schemas/kulturdaten.berlin.openapi.generated.yml
@@ -410,6 +410,23 @@ paths:
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/asReference"
+        - name: inFuture
+          in: query
+          required: false
+          description: >
+            Filters the events based on their occurrence in the future.
+
+            When set to true, returns only events that are scheduled to occur in
+            the future.
+
+            When set to false, returns events regardless of their scheduled
+            date.
+
+            If not provided, the default behavior is to return only events in
+            the future.
+          schema:
+            type: boolean
+            default: true
         - name: organizedBy
           in: query
           required: false
@@ -442,8 +459,8 @@ paths:
 
             When set to true, returns only the events that are free of charge. 
 
-            When set to false, returns only the events that are not free of
-            charge. 
+            When set to false, returns events regardless of their admission
+            charge status.
 
             If not provided, all events are returned irrespective of their
             admission charge status.

--- a/src/schemas/models/AttractionWithEvents.yml
+++ b/src/schemas/models/AttractionWithEvents.yml
@@ -1,8 +1,0 @@
-type: object
-properties:
-  attraction:
-    $ref: "Attraction.yml"
-  events:
-    type: array
-    items:
-      $ref: "Event.yml"

--- a/src/schemas/models/AttractionWithEvents.yml
+++ b/src/schemas/models/AttractionWithEvents.yml
@@ -1,0 +1,8 @@
+type: object
+properties:
+  attraction:
+    $ref: "Attraction.yml"
+  events:
+    type: array
+    items:
+      $ref: "Event.yml"

--- a/src/schemas/models/GetAttractionResponse.yml
+++ b/src/schemas/models/GetAttractionResponse.yml
@@ -12,6 +12,14 @@ properties:
       attractionReference:
         $ref: "Reference.yml"
     additionalProperties: false
+  related:
+    type: object
+    properties:
+      events:
+        type: array
+        items:
+          $ref: "Event.yml"
+    additionalProperties: false
 required:
   - success
 additionalProperties: false

--- a/src/schemas/models/GetAttractionsResponse.yml
+++ b/src/schemas/models/GetAttractionsResponse.yml
@@ -17,10 +17,17 @@ properties:
             type: array
             items:
               $ref: "Reference.yml"
-          attractionsWithEvents:
-            type: array
-            items:
-              $ref: "AttractionWithEvents.yml"
+  related:
+    type: object
+    properties:
+      events:
+        type: array
+        items:
+          $ref: "Event.yml"
+      eventsReferences:
+        type: array
+        items:
+          $ref: "Reference.yml"
 required:
   - success
 additionalProperties: false

--- a/src/schemas/models/GetAttractionsResponse.yml
+++ b/src/schemas/models/GetAttractionsResponse.yml
@@ -17,6 +17,10 @@ properties:
             type: array
             items:
               $ref: "Reference.yml"
+          attractionsWithEvents:
+            type: array
+            items:
+              $ref: "AttractionWithEvents.yml"
 required:
   - success
 additionalProperties: false

--- a/src/schemas/models/GetEventsResponse.yml
+++ b/src/schemas/models/GetEventsResponse.yml
@@ -17,6 +17,17 @@ properties:
             type: array
             items:
               $ref: "Reference.yml"
+  related:
+    type: object
+    properties:
+      attractions:
+        type: array
+        items:
+          $ref: "Attraction.yml"
+      attractionsReferences:
+        type: array
+        items:
+          $ref: "Reference.yml"
 required:
   - success
 additionalProperties: false

--- a/src/schemas/models/Response.yml
+++ b/src/schemas/models/Response.yml
@@ -8,6 +8,8 @@ properties:
     type: object
   error:
     $ref: "Error.yml"
+  related:
+    type: object
 required:
   - success
 additionalProperties: false

--- a/src/utils/RequestUtil.ts
+++ b/src/utils/RequestUtil.ts
@@ -39,3 +39,12 @@ export const extractArrayQueryParam = (req: express.Request, paramName: string):
 		return undefined;
 	}
 };
+
+export const parseBooleanParameter = (req: express.Request, paramName: string): boolean | undefined => {
+	const paramValue = req.query[paramName];
+	if (paramValue === undefined) {
+		return undefined;
+	} else {
+		return (paramValue + "").toLowerCase() === "true";
+	}
+};

--- a/src/utils/RequestUtil.ts
+++ b/src/utils/RequestUtil.ts
@@ -29,13 +29,13 @@ function adjust(value: number, defaultMinValue: number, defaultMaxValue?: number
 	return value;
 }
 
-export const extractArrayQueryParam = (req: express.Request, paramName: string): string[] => {
+export const extractArrayQueryParam = (req: express.Request, paramName: string): string[] | undefined => {
 	const paramValue = req.query[paramName];
 	if (Array.isArray(paramValue)) {
 		return paramValue as string[];
 	} else if (paramValue) {
 		return [paramValue as string];
 	} else {
-		return [];
+		return undefined;
 	}
 };

--- a/src/utils/RequestUtil.ts
+++ b/src/utils/RequestUtil.ts
@@ -28,3 +28,14 @@ function adjust(value: number, defaultMinValue: number, defaultMaxValue?: number
 	}
 	return value;
 }
+
+export const extractArrayQueryParam = (req: express.Request, paramName: string): string[] => {
+	const paramValue = req.query[paramName];
+	if (Array.isArray(paramValue)) {
+		return paramValue as string[];
+	} else if (paramValue) {
+		return [paramValue as string];
+	} else {
+		return [];
+	}
+};

--- a/src/utils/RequestUtil.ts
+++ b/src/utils/RequestUtil.ts
@@ -5,12 +5,12 @@ import { pagination } from "../config/Config";
 
 const log: debug.IDebugger = debug("app:request-utils");
 
-export function getPagination(req: express.Request): Pagination {
+export function getPagination(req: express.Request, complexRequest?: boolean): Pagination {
 	let page: number = extractFromQuery(req.query.page, pagination.defaultPage);
 	let pageSize: number = extractFromQuery(req.query.pageSize, pagination.defaultPageSize);
 
 	page = adjust(page, 1);
-	pageSize = adjust(pageSize, 1, pagination.maxPageSize);
+	pageSize = adjust(pageSize, 1, complexRequest ? pagination.maxComplexRequestPageSize : pagination.maxPageSize);
 
 	return new Pagination(page, pageSize);
 }


### PR DESCRIPTION
Hier wird ein Boolean 'withEvents' zu den Abfragen "GET /attractions" und "GET /attractions/{identifier}" hinzugefügt, der es erlaubt, alle zu den abgefragten Attractions gehörigen Events mit abzufragen. Der Response enthält hierfür neben der Property "data" die Property "related" mit den entsprechenden Events.
Es ist Absicht, dass diese nicht Teil der jeweiligen Attraction sind, sondern alle in einem Array stehen. Die Performance wäre sonst (noch) schlechter und der typische Anwendungsfall ist, dass man die Events mit entsprechendem Attractions-Titel anzeigen möchte und nicht die Attractions. Also, eine Liste mit allen Events, die bestimmte Kriterien bzgl. Attraction beinhalten.